### PR TITLE
Fix ExaCA grain ID to orientation and color mapping

### DIFF
--- a/myna/application/exaca/color.py
+++ b/myna/application/exaca/color.py
@@ -12,20 +12,30 @@ import pyebsd
 
 # Get RGB values for each orientation
 def add_pyebsd_rgb_color(df, refDir=[0, 0, 1], suffix=""):
-    # Initialize rotation matrix array and put Euler-Bunge angles in correct order for pyebsd
+
+    # Get column ids for Euler angles
     ref_cols = ["phi1", "Phi", "phi2"]
     ref_cols_ids = [df.columns.get_loc(x) for x in ref_cols]
+
+    # Calculate active rotation matrix (crystal -> sample)
     R = pyebsd.ebsd.orientation.euler_angles_to_rotation_matrix(
         df.iloc[:, ref_cols_ids[0]],
         df.iloc[:, ref_cols_ids[1]],
         df.iloc[:, ref_cols_ids[2]],
         conv="zxz",
     )
+
+    # Transform from active rotation (crystal -> sample)
+    # to passive rotation (sample -> crystal)
+    R = np.linalg.inv(R)
     orientation = pyebsd.ebsd.orientation.IPF(R, refDir)
 
-    # Convert rotation matrices (orientation) to RGB colors
-    color = np.full((len(orientation), 4), 255, dtype=int)
-    color[:, :3] = pyebsd.ebsd.plotting.get_color_IPF(orientation)
+    # Convert passive rotation matrices (orientation) to RGB colors
+    # using settings to approximate the MTEX toolbox default IPF color mapping
+    color = np.full((len(orientation), 3), 255, dtype=int)
+    color[:, :3] = pyebsd.ebsd.plotting.get_color_IPF(
+        orientation, pwr=0.4, whitespot=[2, 1, 3]
+    )
 
     # Set grain color
     df[f"R{suffix}"] = color[:, 0] / 255

--- a/myna/application/exaca/export.py
+++ b/myna/application/exaca/export.py
@@ -24,7 +24,7 @@ def add_rgb_to_vtk(
     Args:
         vtk_file_path: path to VTK file to add RGB colors to
         vtk_export_path: path for export of modified VTK file
-        lookup_name: path to the lookup table of grain ID orientations (e.g., GrainOrientationVectors.csv)
+        lookup_name: path to the lookup table of Reference ID orientations (e.g., GrainOrientationVectors.csv)
     """
 
     # Read the VTK file
@@ -54,7 +54,7 @@ def add_rgb_to_vtk(
     vtk_dataset.SetOrigin(origin)
 
     # Add scalar data to vtk_dataset from dataframe
-    scalar_names = ["gid", "Grain ID"]
+    scalar_names = ["gid", "Reference ID"]
     scalar_types = [vtk.VTK_INT, vtk.VTK_INT]
     for col, val_type in zip(scalar_names, scalar_types):
         vtk_data = numpy_to_vtk(num_array=df[col].to_numpy(), array_type=val_type)

--- a/myna/application/exaca/subgrain.py
+++ b/myna/application/exaca/subgrain.py
@@ -48,7 +48,7 @@ def rotate_grains(
         )
         t3 = time.perf_counter()
 
-        # Update grain IDs in merged DataFrame to match the
+        # Update Reference IDs in merged DataFrame to match the
         # rotated grain orientation vectors (if specified)
         if update_ids:
             chunk_size = 25000
@@ -81,8 +81,8 @@ def rotate_grains(
                 # Find index of minimum difference for each rotated grain orientation vector
                 min_indices = np.argmin(norms, axis=1)
 
-                # Update grain IDs in merged DataFrame
-                col_id = dfMerged.columns.get_loc("Grain ID")
+                # Update reference IDs in merged DataFrame
+                col_id = dfMerged.columns.get_loc("Reference ID")
                 if i1 >= len(grain_indices):
                     dfMerged.iloc[grain_indices[i0:], col_id] = ref_id[min_indices]
                 else:


### PR DESCRIPTION
There was an incorrect mapping of the ExaCA Grain ID to the Reference ID for the corresponding orientation. This has been corrected.

There were also some cases where the mapping of the rotation matrix to the Euler angles using the `pyebsd` function returned NaN values. A custom function for converting rotation matrices to Euler angles in the Bunge ZXZ convention has been implemented in the ExaCA app.