### PR TITLE
fix: quoted paths in peregrine launcher and base app typo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ logs/
 
 # expected modifications to the example Peregrine resource directory
 *.parquet
+resources/Myna

--- a/myna/application/thesis/melt_pool_geometry_part/execute.py
+++ b/myna/application/thesis/melt_pool_geometry_part/execute.py
@@ -82,7 +82,7 @@ def run_case(
     return [result_file, procs]
 
 
-def main(argv=None):
+def main():
     # Set up simulation object
     sim = Thesis("melt_pool_geometry_part")
 
@@ -121,4 +121,4 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()

--- a/myna/core/app/base.py
+++ b/myna/core/app/base.py
@@ -73,7 +73,7 @@ class MynaApp:
         )
         self.parser.add_argument(
             "--skip",
-            dest="batch",
+            dest="skip",
             default=False,
             action="store_true",
             help="(flag) if parsed by the app, skip the corresponding"

--- a/myna/core/workflow/launch_from_peregrine.py
+++ b/myna/core/workflow/launch_from_peregrine.py
@@ -135,7 +135,7 @@ def launch_from_peregrine(parser):
 
         # Construct myna config command
         lines.append("\nStarting configuration of simulation cases:\n")
-        cmd = f"myna config --input {input_file_configured}"
+        cmd = f'myna config --input "{input_file_configured}"'
         p = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
@@ -154,7 +154,7 @@ def launch_from_peregrine(parser):
 
         # Construct myna run command
         lines.append("\nStarting simulation pipeline execution:\n")
-        cmd = f"myna run --input {input_file_configured}"
+        cmd = f'myna run --input "{input_file_configured}"'
         p = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
@@ -173,7 +173,7 @@ def launch_from_peregrine(parser):
 
         # Construct myna sync command
         lines.append("Syncing simulation results to Peregrine:\n")
-        cmd = f"myna sync --input {input_file_configured}"
+        cmd = f'myna sync --input "{input_file_configured}"'
         p = subprocess.run(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )


### PR DESCRIPTION
Fixes two bugs:

- The Peregrine launcher would fail if the build directory contained a space
- The "skip" parameter in the base app was being assigned to the incorrect argument name