### PR TITLE
add microstructure_region mode to peregrine cli and update workspace

### DIFF
--- a/cli/peregrine_launcher/input_microstructure_region.yaml
+++ b/cli/peregrine_launcher/input_microstructure_region.yaml
@@ -1,0 +1,10 @@
+steps:
+- rve_center:
+    class: rve_part_center
+    application: rve
+- additivefoam:
+    class: solidification_region_reduced
+    application: additivefoam
+- exaca:
+    class: microstructure_region_slice
+    application: exaca

--- a/cli/peregrine_launcher/peregrine_default_workspace.yaml
+++ b/cli/peregrine_launcher/peregrine_default_workspace.yaml
@@ -3,7 +3,7 @@ additivefoam:
     configure:
       coarse: 80e-6
       pad-sub: 1e-3
-      pad-xy: 0.00125
+      pad-xy: 0.0015
       pad-z: 0.0005
       refine-layer: 1
       refine-region: 1
@@ -16,6 +16,16 @@ exaca:
       cell-size: 2.5
       nd: 250
       sub-size: 12.3
+      mu: 5
+      std: 0.5
+    executable: ExaCA
+  microstructure_region_slice:
+    configure:
+      cell-size: 2.5
+      nd: 250
+      sub-size: 12.3
+      mu: 5
+      std: 0.5
     executable: ExaCA
 thesis:
   melt_pool_geometry_part:


### PR DESCRIPTION
This enables the `microstructure_region` mode to be launched from Peregrine to generate and sync the microstructure statistics for a region using the `rve_part_center` -> `additivefoam/solidification_region_reduced` -> `exaca/microstructure_region_slice` application pipeline.