### PR TITLE
set default value if component executable not set in workspace

### DIFF
--- a/myna/core/components/component.py
+++ b/myna/core/components/component.py
@@ -151,7 +151,7 @@ class Component:
                 workspace_dict = load_input(self.workspace)
                 workspace_dict = workspace_dict.get(self.component_application, {})
                 workspace_dict = workspace_dict.get(self.component_class, {})
-                self.executable = workspace_dict["executable"]
+                self.executable = workspace_dict.get("executable", self.executable)
             self.executable = step_settings.get("executable", self.executable)
 
             # If an output_template is specified, use it.


### PR DESCRIPTION
Bug fix to enable proper functioning for workflow applications that do not need an executable due to being pure Python applications, for example, the "rve" applications.

This bug only occurred when using a workspace file.