### PR TITLE
OpenFOAM space handling

### DIFF
--- a/myna/application/additivefoam/solidification_region_reduced/execute.py
+++ b/myna/application/additivefoam/solidification_region_reduced/execute.py
@@ -68,7 +68,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
     cores = args.cores
     batch = args.batch
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
     overwrite = args.overwrite
 
     # Get expected Myna output files

--- a/myna/application/additivefoam/solidification_region_stl/execute.py
+++ b/myna/application/additivefoam/solidification_region_stl/execute.py
@@ -68,7 +68,7 @@ def main(argv=None):
     args = parser.parse_args(argv)
     cores = args.cores
     batch = args.batch
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
     overwrite = args.overwrite
 
     # Get expected Myna output files

--- a/myna/application/bnpy/cluster_solidification/execute.py
+++ b/myna/application/bnpy/cluster_solidification/execute.py
@@ -300,7 +300,7 @@ def main(argv=None):
 
     # Parse command line arguments
     args = parser.parse_args(argv)
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
     train_model = args.train_model
     overwrite = args.overwrite
 

--- a/myna/application/bnpy/cluster_supervoxel/execute.py
+++ b/myna/application/bnpy/cluster_supervoxel/execute.py
@@ -337,7 +337,7 @@ def main(argv=None):
 
     # Parse command line arguments
     args = parser.parse_args(argv)
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
     train_model = args.train_model
     overwrite = args.overwrite
     resolution = args.res

--- a/myna/application/exaca/microstructure_region/execute.py
+++ b/myna/application/exaca/microstructure_region/execute.py
@@ -79,7 +79,7 @@ def main():
     overwrite = args.overwrite
     batch = args.batch
     ranks = args.ranks
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
 
     # Get expected Myna output files
     step_name = os.environ["MYNA_STEP_NAME"]

--- a/myna/application/exaca/microstructure_region/postprocess.py
+++ b/myna/application/exaca/microstructure_region/postprocess.py
@@ -29,7 +29,7 @@ def main(argv=None):
     # Parse args
     args = parser.parse_args(argv)
     input = args.input
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
 
     # Get expected Myna output files
     step_name = os.environ["MYNA_STEP_NAME"]

--- a/myna/application/openfoam/mesh_part_vtk/configure.py
+++ b/myna/application/openfoam/mesh_part_vtk/configure.py
@@ -44,7 +44,7 @@ def main(argv=None):
 
     # Parse command line arguments and get Myna settings
     args = parser.parse_args(argv)
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
     template = args.template
 
     # Get expected Myna output files to identify output directories

--- a/myna/application/openfoam/mesh_part_vtk/execute.py
+++ b/myna/application/openfoam/mesh_part_vtk/execute.py
@@ -78,7 +78,7 @@ def main(argv=None):
     scale = args.scale
     coarse_res = args.coarse
     refinement_level = args.refine
-    settings = load_input(os.environ["MYNA_RUN_INPUT"])
+    settings = load_input(os.environ["MYNA_INPUT"])
 
     # Get expected Myna output files
     step_name = os.environ["MYNA_STEP_NAME"]
@@ -97,7 +97,7 @@ def main(argv=None):
         shutil.rmtree(os.path.join(case_dir, "VTK"), ignore_errors=True)
 
         # Clean .obj files if they were created
-        input_dir = os.path.dirname(os.environ["MYNA_RUN_INPUT"])
+        input_dir = os.path.dirname(os.environ["MYNA_INPUT"])
         obj_files = glob.glob(os.path.join(input_dir, "*.obj"))
         for obj_file in obj_files:
             os.remove(obj_file)

--- a/myna/application/rve/rve_selection/execute.py
+++ b/myna/application/rve/rve_selection/execute.py
@@ -372,7 +372,7 @@ def main(argv=None):
     bid = args.bid
 
     # Get input settings
-    input_file = os.environ["MYNA_RUN_INPUT"]
+    input_file = os.environ["MYNA_INPUT"]
     settings = load_input(input_file)
 
     # Get expected Myna output files

--- a/myna/core/app/base.py
+++ b/myna/core/app/base.py
@@ -13,14 +13,14 @@ from myna.core.workflow.load_input import load_input
 
 
 class MynaApp:
-    settings = "MYNA_RUN_INPUT"
+    settings = "MYNA_INPUT"
     path = "MYNA_APP_PATH"
     step_name = "MYNA_STEP_NAME"
     last_step_name = "MYNA_LAST_STEP_NAME"
 
     def __init__(self, name):
         self.name = name
-        self.input_file = os.environ["MYNA_RUN_INPUT"]
+        self.input_file = os.environ["MYNA_INPUT"]
         self.settings = load_input(self.input_file)
         self.path = os.environ["MYNA_APP_PATH"]
         self.step_name = os.environ["MYNA_STEP_NAME"]

--- a/myna/core/components/component.py
+++ b/myna/core/components/component.py
@@ -186,6 +186,7 @@ class Component:
         files = []
 
         # Get build name
+        input_dir = os.path.abspath(os.path.dirname(os.environ["MYNA_INPUT"]))
         build = self.data["build"]["name"]
 
         # Get all other names that are set by the component
@@ -216,14 +217,25 @@ class Component:
                                 layers = r["layers"]
                                 filelist = [
                                     os.path.join(
-                                        build, part, region, str(x), self.name, template
+                                        input_dir,
+                                        build,
+                                        part,
+                                        region,
+                                        str(x),
+                                        self.name,
+                                        template,
                                     )
                                     for x in layers
                                 ]
                             else:
                                 filelist = [
                                     os.path.join(
-                                        build, part, region, self.name, template
+                                        input_dir,
+                                        build,
+                                        part,
+                                        region,
+                                        self.name,
+                                        template,
                                     )
                                 ]
                             files.extend(filelist)
@@ -231,15 +243,21 @@ class Component:
                         if "layer" in vars:
                             layers = self.data["build"]["parts"][part]["layers"]
                             filelist = [
-                                os.path.join(build, part, str(x), self.name, template)
+                                os.path.join(
+                                    input_dir, build, part, str(x), self.name, template
+                                )
                                 for x in layers
                             ]
                         else:
-                            filelist = [os.path.join(build, part, self.name, template)]
+                            filelist = [
+                                os.path.join(
+                                    input_dir, build, part, self.name, template
+                                )
+                            ]
                         files.extend(filelist)
 
         elif len(self.types) == 1:
-            files.append(os.path.join(build, self.name, template))
+            files.append(os.path.join(input_dir, build, self.name, template))
 
         else:
             print(

--- a/myna/core/metadata/file.py
+++ b/myna/core/metadata/file.py
@@ -42,7 +42,10 @@ class BuildFile:
     def set_local_resource_dir(self):
         """Get the local resource directory and make if it doesn't exist"""
 
-        resource_dir = os.path.abspath(os.path.join(".", "myna_resources"))
+        input_dir = os.path.abspath(os.path.dirname(os.environ["MYNA_INPUT"]))
+        if input_dir is None:
+            input_dir = "."
+        resource_dir = os.path.abspath(os.path.join(input_dir, "myna_resources"))
         os.makedirs(resource_dir, exist_ok=True)
         self.resource_dir = resource_dir
 

--- a/myna/core/workflow/config.py
+++ b/myna/core/workflow/config.py
@@ -68,6 +68,10 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
       show_avail: only shows available data files, but does not copy
       overwrite: flag to overwrite existing files in Myna resources"""
 
+    # Set environmental variable for input file location
+    os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
+
+    # Set output file
     if output_file is None:
         output_file = input_file
 
@@ -286,6 +290,9 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
             build_struct = (
                 os.path.abspath(case_dir).replace(base_path, "").split(os.sep)
             )
+            print(f"{build_struct=}")
+            print(f"{base_path=}")
+            print(f"{case_dir=}")
             if "part" in step_obj.types:
                 part = build_struct[2]
                 keys = list(data_dict_case["build"]["parts"].keys())

--- a/myna/core/workflow/config.py
+++ b/myna/core/workflow/config.py
@@ -70,6 +70,9 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
 
     # Set environmental variable for input file location
     os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
+    os.environ["MYNA_CONFIG_INPUT"] = os.path.abspath(
+        input_file
+    )  # MYNA_CONFIG_INPUT will be deprecated in future versions
 
     # Set output file
     if output_file is None:
@@ -290,9 +293,6 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
             build_struct = (
                 os.path.abspath(case_dir).replace(base_path, "").split(os.sep)
             )
-            print(f"{build_struct=}")
-            print(f"{base_path=}")
-            print(f"{case_dir=}")
             if "part" in step_obj.types:
                 part = build_struct[2]
                 keys = list(data_dict_case["build"]["parts"].keys())

--- a/myna/core/workflow/run.py
+++ b/myna/core/workflow/run.py
@@ -49,6 +49,9 @@ def run(input_file, step=None):
 
     # Set environmental variable for input file location
     os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
+    os.environ["MYNA_RUN_INPUT"] = os.path.abspath(
+        input_file
+    )  # MYNA_RUN_INPUT will be deprecated in future versions
 
     # Load the initial input file to get the steps
     initial_settings = load_input(input_file)

--- a/myna/core/workflow/run.py
+++ b/myna/core/workflow/run.py
@@ -48,7 +48,7 @@ def run(input_file, step=None):
     steps_to_run = myna.core.utils.str_to_list(step)
 
     # Set environmental variable for input file location
-    os.environ["MYNA_RUN_INPUT"] = os.path.abspath(input_file)
+    os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
 
     # Load the initial input file to get the steps
     initial_settings = load_input(input_file)

--- a/myna/core/workflow/sync.py
+++ b/myna/core/workflow/sync.py
@@ -50,6 +50,9 @@ def sync(input_file, step=None):
 
     # Set environmental variable for input file location
     os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
+    os.environ["MYNA_SYNC_INPUT"] = os.path.abspath(
+        input_file
+    )  # MYNA_SYNC_INPUT will be deprecated in future versions
 
     # Load the initial input file to get the steps
     initial_settings = load_input(input_file)

--- a/myna/core/workflow/sync.py
+++ b/myna/core/workflow/sync.py
@@ -49,7 +49,7 @@ def sync(input_file, step=None):
     steps_to_sync = myna.core.utils.str_to_list(step)
 
     # Set environmental variable for input file location
-    os.environ["MYNA_SYNC_INPUT"] = os.path.abspath(input_file)
+    os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
 
     # Load the initial input file to get the steps
     initial_settings = load_input(input_file)

--- a/myna/database/peregrine.py
+++ b/myna/database/peregrine.py
@@ -238,7 +238,7 @@ class PeregrineDB(Database):
             component_name = os.path.basename(os.path.dirname(files[0]))
             unique_regions = sorted(set(regions))
             unique_parts = sorted(set(parts))
-            settings = load_input(os.environ["MYNA_SYNC_INPUT"])
+            settings = load_input(os.environ["MYNA_INPUT"])
             for region in unique_regions:
                 for part in unique_parts:
                     part_dict = nested_get(settings, ["data", "build", "parts"]).get(

--- a/tests/test_peregrine_cli.py
+++ b/tests/test_peregrine_cli.py
@@ -35,6 +35,8 @@ def test_peregrine_cli():
         f"{myna_path}/cli/peregrine_launcher/peregrine_default_workspace.yaml",
         "--mode",
         "meltpool_geometry",
+        "--tmp-dir",
+        "~/myna_tmp",
     ]
     myna.core.workflow.launch_from_peregrine(parser)
 


### PR DESCRIPTION
OpenFOAM cannot handle spaces in file paths, which is incompatible with the Peregrine CLI workflow. These changes use a temporary directory (which must not contain spaces in the path) to do all of the calculations before finally moving files to the intended location.

Closes #43.