### PR TITLE
AdditiveFOAM update to use Mist material files

### DIFF
--- a/myna/application/additivefoam/additivefoam.py
+++ b/myna/application/additivefoam/additivefoam.py
@@ -8,6 +8,7 @@
 #
 import os, shutil
 import yaml
+import mistlib as mist
 
 from myna.core.app.base import MynaApp
 
@@ -126,3 +127,19 @@ class AdditiveFOAM(MynaApp):
                     yaml.dump(mesh_dict, f, default_flow_style=None)
 
         return use_existing_mesh
+
+    def update_material_properties(self, case_dir):
+
+        material = self.settings["data"]["build"]["build_data"]["material"]["value"]
+        material_data = os.path.join(
+            os.environ["MYNA_INSTALL_PATH"],
+            "resources",
+            "mist_material_data",
+            f"{material}.json",
+        )
+        mat = mist.core.MaterialInformation(material_data)
+        transport_filepath = os.path.join(case_dir, "constant", "transportProperties")
+        thermo_filepath = os.path.join(case_dir, "constant", "thermoPath")
+        mat.write_additivefoam_input(
+            transport_file=transport_filepath, thermo_file=thermo_filepath
+        )

--- a/myna/application/additivefoam/solidification_region_reduced/configure.py
+++ b/myna/application/additivefoam/solidification_region_reduced/configure.py
@@ -132,12 +132,12 @@ def setup_case(case_dir, app):
     }
 
     # Generate cases based on inputs
-    generate(additivefoam_input_dict, settings, use_existing_mesh)
+    generate(additivefoam_input_dict, settings, use_existing_mesh, app)
 
     return
 
 
-def generate(additivefoam_input_dict, myna_settings, use_existing_mesh):
+def generate(additivefoam_input_dict, myna_settings, use_existing_mesh, app):
     # Set paths
     case_dir = additivefoam_input_dict["case_dir"]
     template_dir = os.path.abspath(additivefoam_input_dict["template"]["template_dir"])
@@ -254,9 +254,14 @@ def generate(additivefoam_input_dict, myna_settings, use_existing_mesh):
         bb = bb_min + bb_max
         bbDict = {"bb_min": bb_min, "bb_max": bb_max, "bb": bb}
 
-    ##############################
-    # Copy template to case  dir #
-    ##############################
+    ###############################
+    # Set the material properties #
+    ###############################
+    app.update_material_properties(template_dir)
+
+    #############################
+    # Copy template to case dir #
+    #############################
     shutil.copytree(template_dir, case_dir, dirs_exist_ok=True)
 
     ##############################

--- a/myna/application/additivefoam/solidification_region_stl/configure.py
+++ b/myna/application/additivefoam/solidification_region_stl/configure.py
@@ -168,6 +168,7 @@ def setup_case(case_dir, app):
         settings,
         use_existing_stl_mesh,
         use_existing_region_mesh,
+        app,
     )
 
     return
@@ -178,6 +179,7 @@ def generate(
     myna_settings,
     use_existing_stl_mesh,
     use_existing_region_mesh,
+    app,
 ):
     # Set paths
     case_dir = additivefoam_input_dict["case_dir"]
@@ -322,6 +324,11 @@ def generate(
             f" -set '( ({refinement} {refinement}) );' {refine_dict_path}"
         )
         openfoam.mesh.refine_RVE(template_dir, additivefoam_input_dict["region_box"])
+
+    ###############################
+    # Set the material properties #
+    ###############################
+    app.update_material_properties(template_dir)
 
     ##############################
     # Copy template to case  dir #

--- a/resources/mist_material_data/SS316H.json
+++ b/resources/mist_material_data/SS316H.json
@@ -30,7 +30,7 @@
         },
         "thermal_conductivity_solid": {
             "print_name": "Thermal conductivity (solid)",
-            "value_laurent_poly": [[0.6658, 0], [1.571e-2, 1]],
+            "value_laurent_poly": [[9.248, 0], [1.571e-2, 1]],
             "dependent_variable_print_name": "Temperature",
             "dependent_variable_print_symbol": "T",
             "dependent_variable_unit": "K",
@@ -41,7 +41,7 @@
         },
         "thermal_conductivity_liquid": {
             "print_name": "Thermal conductivity (liquid)",
-            "value_laurent_poly": [[10.61, 0], [3.279e-3, 1]],
+            "value_laurent_poly": [[1.241e1, 0], [3.279e-3, 1]],
             "dependent_variable_print_name": "Temperature",
             "dependent_variable_print_symbol": "T",
             "dependent_variable_unit": "K",
@@ -131,5 +131,5 @@
             "print_symbol": "\\alpha"
         }
     },
-    "note": "This file currently excludes the surface tension, marangoni coefficient, and the vapor pressure due to the need for function representations other than Laurent polynomials. All references refer to SS316L data because of similarity of physical properties."
+    "note": "This file currently excludes the surface tension, marangoni coefficient, and the vapor pressure due to the need for function representations other than Laurent polynomials."
 }

--- a/resources/mist_material_data/SS316L.json
+++ b/resources/mist_material_data/SS316L.json
@@ -30,7 +30,7 @@
         },
         "thermal_conductivity_solid": {
             "print_name": "Thermal conductivity (solid)",
-            "value_laurent_poly": [[0.6658, 0], [1.571e-2, 1]],
+            "value_laurent_poly": [[9.248, 0], [1.571e-2, 1]],
             "dependent_variable_print_name": "Temperature",
             "dependent_variable_print_symbol": "T",
             "dependent_variable_unit": "K",
@@ -41,7 +41,7 @@
         },
         "thermal_conductivity_liquid": {
             "print_name": "Thermal conductivity (liquid)",
-            "value_laurent_poly": [[10.61, 0], [3.279e-3, 1]],
+            "value_laurent_poly": [[1.241e1, 0], [3.279e-3, 1]],
             "dependent_variable_print_name": "Temperature",
             "dependent_variable_print_symbol": "T",
             "dependent_variable_unit": "K",


### PR DESCRIPTION
AdditiveFOAM apps now use Mist material files from the Myna resource directory to set materials properties for simulations.

Closes #7.