### PR TITLE
update scanpath padding in peregrinehdf5 export

### DIFF
--- a/src/myna/database/peregrine_hdf5.py
+++ b/src/myna/database/peregrine_hdf5.py
@@ -192,11 +192,11 @@ class PeregrineHDF5(PeregrineDB):
                 max_y = np.max(inds[:, iy]) + 1
 
                 # Convert bounds to millimeters
-                pad = 2  # px
-                min_x = 0.5 * dx + dx * (min_x - pad)
-                min_y = 0.5 * dy + dy * (min_y - pad)
-                max_x = 0.5 * dx + dx * (max_x + pad)
-                max_y = 0.5 * dy + dy * (max_y + pad)
+                pad = 3  # px
+                min_x = dx * (min_x - pad - 0.5)
+                min_y = dy * (min_y - pad - 0.5)
+                max_x = dx * (max_x + pad + 0.5)
+                max_y = dy * (max_y + pad + 0.5)
 
                 # Invert the y-axis to match part_id map
                 df_scan["ys"] = y_dim - df_scan["ys"]


### PR DESCRIPTION
Some ends of scan paths were getting cut off when extracting scan paths from the PeregrineHDF5 datasets. 

This PR adds another pixel of padding to the bounding box used for searching for scan vectors within the part. It also corrects the logic for calculating the bounding box, which had a typo.