### PR TITLE
fix check for existing mesh in additivefoam apps

### DIFF
--- a/src/myna/application/additivefoam/additivefoam.py
+++ b/src/myna/application/additivefoam/additivefoam.py
@@ -94,39 +94,38 @@ class AdditiveFOAM(MynaApp):
             "additiveFoam",
         )
 
-    def copy(self, case_dir, mesh_path, mesh_dict):
-        use_existing_mesh = False
-        # If no template mesh dict exists, write it
-        if (not os.path.exists(mesh_path)) or (self.args.overwrite):
-            shutil.copytree(self.args.template, case_dir, dirs_exist_ok=True)
+    def copy_template_to_dir(self, target_dir):
+        """Copies the specified template directory to the specified target directory"""
+        # Ensure directory structure to target exists
+        os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+        if self.args.template is not None:
+            shutil.copytree(self.args.template, target_dir, dirs_exist_ok=True)
 
-            with open(mesh_path, "w") as f:
-                yaml.dump(mesh_path, f, default_flow_style=False)
+    def has_matching_template_mesh_dict(self, mesh_path, mesh_dict):
+        """Checks if there is a usable mesh dictionary in the case directory
+
+        Args:
+            mesh_path: path to the template mesh dictionary
+            mesh_dict: dictionary object containing the template mesh dictionary
+
+        Return:
+            Boolean: True/False if template mesh dict matches
+        """
+        if (not os.path.exists(mesh_path)) or (self.args.overwrite):
+            return False
 
         # If template mesh dict exists, then check if it matches current
         # build, part, and region
+        with open(mesh_path, "r", encoding="utf-8") as f:
+            existing_dict = yaml.safe_load(f)
+        matches = []
+        for key in mesh_dict.keys():
+            entry_match = mesh_dict.get(key) == existing_dict.get(key)
+            matches.append(entry_match)
+        if all(matches):
+            return True
         else:
-            print(f"Warning: NOT overwriting existing case in: {case_dir}")
-
-            with open(mesh_path, "r") as f:
-                existing_dict = yaml.safe_load(f)
-            try:
-                matches = []
-                for key in mesh_dict.keys():
-                    entry_match = mesh_dict.get(key) == existing_dict.get(key)
-                    matches.append(entry_match)
-                if all(matches):
-                    use_existing_mesh = True
-                else:
-                    shutil.copytree(self.args.template, case_dir, dirs_exist_ok=True)
-                    with open(mesh_path, "w") as f:
-                        yaml.dump(mesh_dict, f, default_flow_style=None)
-            except:
-                shutil.copytree(self.args.template, case_dir, dirs_exist_ok=True)
-                with open(mesh_path, "w") as f:
-                    yaml.dump(mesh_dict, f, default_flow_style=None)
-
-        return use_existing_mesh
+            return False
 
     def update_material_properties(self, case_dir):
 

--- a/src/myna/application/additivefoam/solidification_region_reduced/configure.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced/configure.py
@@ -82,10 +82,14 @@ def setup_case(case_dir, app):
         resource_template_dir, template_mesh_dict_name
     )
 
-    # Copy template files
-    use_existing_mesh = app.copy(
-        resource_template_dir, template_mesh_dict_path, template_mesh_dict
+    # Copy template files if needed
+    use_existing_mesh = app.has_matching_template_mesh_dict(
+        template_mesh_dict_path, template_mesh_dict
     )
+    if not use_existing_mesh:
+        app.copy_template_to_dir(resource_template_dir)
+        with open(template_mesh_dict_path, "w", encoding="utf-8") as f:
+            yaml.dump(template_mesh_dict, f, default_flow_style=None)
 
     # Set input dictionary in format required by functions
     additivefoam_input_dict = {
@@ -295,7 +299,7 @@ def generate(additivefoam_input_dict, myna_settings, use_existing_mesh, app):
                 end_time = None
             if in_region and (start_time is None):
                 start_time = elapsed_time
-            elif (not in_region) and (end_time is None):
+            if (not in_region) and (end_time is None):
                 end_time = elapsed_time
             elapsed_time += np.linalg.norm(np.array([x1 - x0, y1 - y0])) / v
 

--- a/src/myna/application/additivefoam/solidification_region_stl/configure.py
+++ b/src/myna/application/additivefoam/solidification_region_stl/configure.py
@@ -83,34 +83,22 @@ def setup_case(case_dir, app):
 
     # Write template STL mesh dict as needed, and if the template
     # STL mesh dict exists, then check if it matches current mesh settings
-    use_existing_stl_mesh = app.copy(
-        resource_template_dir, template_region_mesh_dict_path, template_stl_mesh_dict
+    use_existing_stl_mesh = app.has_matching_template_mesh_dict(
+        template_stl_mesh_dict_path, template_stl_mesh_dict
     )
+    if not use_existing_stl_mesh:
+        app.copy_template_to_dir(resource_template_dir)
+        with open(template_stl_mesh_dict_path, "w", encoding="utf-8") as f:
+            yaml.dump(template_stl_mesh_dict, f, default_flow_style=None)
 
     # Write template region mesh dict as needed, and if the template region
     # mesh dict exists, then check if it matches current mesh settings
-    use_existing_region_mesh = False
-    if not os.path.exists(template_region_mesh_dict_path):
-        with open(template_region_mesh_dict_path, "w") as f:
-            yaml.dump(template_region_mesh_dict, f, default_flow_style=False)
-    else:
-        with open(template_region_mesh_dict_path, "r") as f:
-            existing_dict = yaml.safe_load(f)
-        try:
-            matches = []
-            for key in template_region_mesh_dict.keys():
-                entry_match = template_region_mesh_dict.get(key) == existing_dict.get(
-                    key
-                )
-                matches.append(entry_match)
-            if all(matches):
-                use_existing_region_mesh = True
-            else:
-                with open(template_region_mesh_dict_path, "w") as f:
-                    yaml.dump(template_region_mesh_dict, f, default_flow_style=None)
-        except:
-            with open(template_region_mesh_dict_path, "w") as f:
-                yaml.dump(template_region_mesh_dict, f, default_flow_style=None)
+    use_existing_region_mesh = app.has_matching_template_mesh_dict(
+        template_region_mesh_dict_path, template_region_mesh_dict
+    )
+    if not use_existing_region_mesh:
+        with open(template_region_mesh_dict_path, "w", encoding="utf-8") as f:
+            yaml.dump(template_region_mesh_dict_name, f, default_flow_style=None)
 
     # Set input dictionary in format required by functions
     additivefoam_input_dict = {
@@ -401,7 +389,7 @@ def generate(
     )
     shutil.move(os.path.join(case_dir, "0"), os.path.join(case_dir, f"{start_time}"))
     os.system(
-        f"foamDictionary -entry beam/pathName -set"
+        "foamDictionary -entry beam/pathName -set"
         + f""" '"{path_name}"' """
         + f"{case_dir}/constant/heatSourceDict"
     )


### PR DESCRIPTION
The check for whether a previously generated mesh could be reused (e.g., the same cube mesh can be used for multiple layers within a part) was broken. The bug came from the fact that the dictionary containing the values used to generate the mesh was not being written. 

This PR fixes this by writing out the dictionary with the mesh generation parameters.