### PR TITLE
updated additivefoam templates for ExaCA functionObject to address #63

### DIFF
--- a/src/myna/application/additivefoam/solidification_region_reduced/template/system/ExaCA
+++ b/src/myna/application/additivefoam/solidification_region_reduced/template/system/ExaCA
@@ -4,22 +4,14 @@
                       Created for simulation with Myna
   ---------------------------------------------------------------------------*/
 
-FoamFile
+ExaCA
 {
-    version         2;
-    format          ascii;
-    class           dictionary;
-    object          foamToExaCADict;
+    type ExaCA;
+    libs ("libExaCAFunctionObject.so");
+    
+    box         ( 0.0495 -0.0495 -0.0003 ) ( 0.0505 -0.0485 0 );
+    dx          2.5e-6;
+    isoValue    1730;
 }
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
-
-execute         on;
-
-box             ( 0.0495 -0.0495 -0.0003 ) ( 0.0505 -0.0485 0 );
-
-dx              2.5e-06;
-
-isotherm        1730;
-
 
 // ************************************************************************* //

--- a/src/myna/application/additivefoam/solidification_region_reduced/template/system/controlDict
+++ b/src/myna/application/additivefoam/solidification_region_reduced/template/system/controlDict
@@ -42,11 +42,18 @@ timeFormat      general;
 
 timePrecision   8;
 
-runTimeModifiable yes;
+runTimeModifiable no;
 
 adjustTimeStep  yes;
 
 maxCo           0.5;
-maxFo           50;
-maxAlphaCo      0.5;
+
+maxDi           100;
+
+maxAlphaCo      1;
+
+functions
+{
+    #includeFunc    ExaCA
+}
 // ************************************************************************* //

--- a/src/myna/application/additivefoam/solidification_region_reduced/template/system/fvSchemes
+++ b/src/myna/application/additivefoam/solidification_region_reduced/template/system/fvSchemes
@@ -31,7 +31,8 @@ divSchemes
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default             Gauss linear corrected;
+    laplacian(kappa,T)	Gauss harmonic corrected;
 }
 
 interpolationSchemes

--- a/src/myna/application/additivefoam/solidification_region_stl/template/system/ExaCA
+++ b/src/myna/application/additivefoam/solidification_region_stl/template/system/ExaCA
@@ -4,22 +4,15 @@
                       Created for simulation with Myna
   ---------------------------------------------------------------------------*/
 
-FoamFile
+ExaCA
 {
-    version         2;
-    format          ascii;
-    class           dictionary;
-    object          foamToExaCADict;
+    type ExaCA;
+    libs ("libExaCAFunctionObject.so");
+    
+    box         ( 0.172 0.072 -0.0003 ) ( 0.173 0.073 0 );
+    dx          2.5e-6;
+    isoValue    1730;
 }
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
-
-execute         on;
-
-box             ( 0.172 0.072 -0.0003 ) ( 0.173 0.073 0 );
-
-dx              2.5e-06;
-
-isotherm        1730;
 
 
 // ************************************************************************* //

--- a/src/myna/application/additivefoam/solidification_region_stl/template/system/controlDict
+++ b/src/myna/application/additivefoam/solidification_region_stl/template/system/controlDict
@@ -47,6 +47,13 @@ runTimeModifiable yes;
 adjustTimeStep  yes;
 
 maxCo           0.5;
-maxFo           50;
-maxAlphaCo      0.5;
+
+maxDi           100;
+
+maxAlphaCo      1;
+
+functions
+{
+    #includeFunc    ExaCA
+}
 // ************************************************************************* //

--- a/src/myna/application/additivefoam/solidification_region_stl/template/system/fvSchemes
+++ b/src/myna/application/additivefoam/solidification_region_stl/template/system/fvSchemes
@@ -31,7 +31,8 @@ divSchemes
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default             Gauss linear corrected;
+    laplacian(kappa,T)	Gauss harmonic corrected;
 }
 
 interpolationSchemes


### PR DESCRIPTION
We have moved the foamToExaCA class, to its own library known as a [functionObject](https://doc.cfd.direct/openfoam/user-guide-v10/post-processing-cli) in OpenFOAM. You can see the changes in the AdditiveFOAM tutorials, where a new [ExaCA dictionary file](https://github.com/ORNL/AdditiveFOAM/blob/main/tutorials/AMB2018-02-B/system/ExaCA) is placed in the system directory and the [controlDict file is appended](https://github.com/ORNL/AdditiveFOAM/blob/6f2fb7e969b0fff485b79c2ba523c5705d4fd90e/tutorials/AMB2018-02-B/system/controlDict#L56) to include this dedicated function.