### PR TITLE
additivefoam: update exaca-related dictionaries automatically

### DIFF
--- a/src/myna/application/additivefoam/additivefoam.py
+++ b/src/myna/application/additivefoam/additivefoam.py
@@ -182,6 +182,14 @@ class AdditiveFOAM(MynaApp):
             + f' -set "{absorption}" {case_dir}/constant/heatSourceDict'
         )
 
+        # Update the isotherm in the ExaCA function dictionary if it exists
+        exaca_dict = f"{case_dir}/system/ExaCA"
+        if os.path.exists(exaca_dict):
+            liquidus = mat.get_property("liquidus_temperature", None, None)
+            os.system(
+                f'foamDictionary -entry ExaCA/isoValue -set "{liquidus}" {exaca_dict}'
+            )
+
     def get_region_resource_template_dir(self, part, region):
         """Provides the path to the template directory in the myna_resources folder
 

--- a/src/myna/application/additivefoam/additivefoam.py
+++ b/src/myna/application/additivefoam/additivefoam.py
@@ -89,6 +89,12 @@ class AdditiveFOAM(MynaApp):
             type=float,
             help="Multiple by which to scale the STL file dimensions (default = 0.001, mm -> m)",
         )
+        self.parser.add_argument(
+            "--exaca-mesh",
+            default=2.5e-6,
+            type=float,
+            help="Mesh size for the ExaCA simulations, in meters",
+        )
 
         self.args = self.parser.parse_args()
 
@@ -360,4 +366,15 @@ class AdditiveFOAM(MynaApp):
             "foamDictionary -entry beam/pathName -set"
             + f""" '"{scanpath_name}"' """
             + f"{case_dir}/constant/heatSourceDict"
+        )
+
+    def update_exaca_mesh_size(self, case_dir):
+        """Updates the ExaCA/dx value based on the app settings
+
+        Args:
+            case_dir: AdditiveFOAM case directory to update
+        """
+        os.system(
+            "foamDictionary -entry ExaCA/dx -set"
+            + f" {self.args.exaca_mesh} {case_dir}/system/ExaCA"
         )

--- a/src/myna/application/additivefoam/solidification_region_reduced/configure.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced/configure.py
@@ -154,6 +154,7 @@ def setup_case(case_dir, app):
     app.update_material_properties(case_dir)
     app.update_region_start_and_end_times(case_dir, bb_dict, path_name)
     app.update_heatsource_scanfile(case_dir, path_name)
+    app.update_exaca_mesh_size(case_dir)
 
     return
 

--- a/src/myna/application/additivefoam/solidification_region_reduced/template/runCase
+++ b/src/myna/application/additivefoam/solidification_region_reduced/template/runCase
@@ -8,8 +8,14 @@ cores=$(foamDictionary -entry numberOfSubdomains -value system/decomposeParDict)
 mpirun -np $cores additiveFoam -parallel > log.additiveFoam 2>&1
 
 # Reconstruct ExaCA data into a single file
+reconstructPar > log.reconstructPar 2>&1
 echo "x,y,z,tm,ts,cr" > solidificationData.csv
 cat ExaCA/* >> solidificationData.csv
 
-# Delete processor directories
-rm -r processor*
+# Clean up decomposed data if the output file exists and contains data
+if [ -e solidificationData.csv ]; then
+    if [ -n "$(find . solidificationData.csv -prune -size +100k)" ]; then
+        rm -r ExaCA
+        rm -r processor*
+    fi
+fi

--- a/src/myna/application/additivefoam/solidification_region_stl/configure.py
+++ b/src/myna/application/additivefoam/solidification_region_stl/configure.py
@@ -202,6 +202,7 @@ def setup_case(case_dir, app):
     app.update_material_properties(case_dir)
     app.update_region_start_and_end_times(case_dir, bb_dict, path_name)
     app.update_heatsource_scanfile(case_dir, path_name)
+    app.update_exaca_mesh_size(case_dir)
 
     return
 

--- a/src/myna/application/additivefoam/solidification_region_stl/template/runCase
+++ b/src/myna/application/additivefoam/solidification_region_stl/template/runCase
@@ -8,5 +8,14 @@ cores=$(foamDictionary -entry numberOfSubdomains -value system/decomposeParDict)
 mpirun -np $cores additiveFoam -parallel > log.additiveFoam 2>&1
 
 # Reconstruct ExaCA data into a single file
+reconstructPar > log.reconstructPar 2>&1
 echo "x,y,z,tm,ts,cr" > solidificationData.csv
 cat ExaCA/* >> solidificationData.csv
+
+# Clean up decomposed data if the output file exists and contains data
+if [ -e solidificationData.csv ]; then
+    if [ -n "$(find . solidificationData.csv -prune -size +100k)" ]; then
+        rm -r ExaCA
+        rm -r processor*
+    fi
+fi

--- a/src/myna/application/openfoam/mesh.py
+++ b/src/myna/application/openfoam/mesh.py
@@ -317,10 +317,10 @@ def slice(case_dir, height):
 
 def refine_RVE(case_dir, bb):
     os.system(
-        f"foamDictionary -entry box -set "
+        f"foamDictionary -entry ExaCA/box -set "
         f'"( {bb[0][0]} {bb[0][1]} {bb[0][2]} ) '
         f'( {bb[1][0]} {bb[1][1]} {bb[1][2]} )" '
-        f"{case_dir}/constant/foamToExaCADict"
+        f"{case_dir}/system/ExaCA"
     )
 
     os.system(


### PR DESCRIPTION
Add and fix options related to the AdditiveFOAM `system/ExaCA` dictionary:

- Fixed: Update box size for refinement using `openfoam.mesh.refine_RVE()`
- Added: Update the isotherm for capturing solidification parameters using Mist database
- Added: Specify the mesh spacing for the ExaCA simulation as a `config` argument from Myna input file (default 2.5e-6 m)

Closes #65, #63