### PR TITLE
fixup: correct `ExaCA(MynaApp)` implementation in `exaca` apps

### DIFF
--- a/src/myna/application/exaca/microstructure_region/configure.py
+++ b/src/myna/application/exaca/microstructure_region/configure.py
@@ -96,6 +96,8 @@ def setup_case(
     df = pl.read_csv(
         nested_get(input_settings, ["TemperatureData", "TemperatureFiles"])[0]
     )
+    if df.is_empty():
+        return
     xmin, xmax = [df["x"].min(), df["x"].max()]
     ymin, ymax = [df["y"].min(), df["y"].max()]
     spacing = nested_get(input_settings, ["Domain", "CellSize"])
@@ -125,7 +127,7 @@ def setup_case(
 def main():
 
     # Create ExaCA instance
-    app = ExaCA()
+    app = ExaCA("microstructure_region")
 
     # Get expected Myna output files
     settings = app.settings

--- a/src/myna/application/exaca/microstructure_region/configure.py
+++ b/src/myna/application/exaca/microstructure_region/configure.py
@@ -9,8 +9,6 @@
 import os
 from myna.core.workflow.load_input import load_input
 from myna.core.utils import nested_get, nested_set
-import argparse
-import sys
 import shutil
 import json
 import numpy as np

--- a/src/myna/application/exaca/microstructure_region/execute.py
+++ b/src/myna/application/exaca/microstructure_region/execute.py
@@ -48,7 +48,7 @@ def run_case(app, case_dir):
 
 
 def main():
-    """Main ExaCA/microstructure_region execution function"""
+    """Main exaca/microstructure_region execution function"""
 
     # Create ExaCA instance
     app = ExaCA("microstructure_region")

--- a/src/myna/application/exaca/microstructure_region_slice/postprocess.py
+++ b/src/myna/application/exaca/microstructure_region_slice/postprocess.py
@@ -17,20 +17,20 @@ from myna.application.exaca import (
 
 
 def main():
+    """Main postprocessing functionality for exaca/microstructure_region_slice"""
 
     # Create ExaCA instance
     app = ExaCA("microstructure_region_slice")
 
     # Get expected Myna output files
-    settings = app.settings
-    myna_files = settings["data"]["output_paths"][app.step_name]
+    myna_files = app.settings["data"]["output_paths"][app.step_name]
 
     # Check if case already has valid output
     step_obj = return_step_class(os.environ["MYNA_STEP_CLASS"])
-    step_dict = settings["steps"][int(os.environ["MYNA_STEP_INDEX"])]
+    step_dict = app.settings["steps"][int(os.environ["MYNA_STEP_INDEX"])]
     step_obj.name = list(step_dict.keys())[0]
     step_obj.apply_settings(
-        step_dict[step_obj.name], settings["data"], settings["myna"]
+        step_dict[step_obj.name], app.settings["data"], app.settings["myna"]
     )
     _, _, files_are_valid = step_obj.get_output_files()
 
@@ -38,23 +38,23 @@ def main():
     for myna_file, valid in zip(myna_files, files_are_valid):
         if not valid:
             continue
-        else:
-            # Get reference file from the inputs.json for the case
-            input_file = os.path.join(os.path.dirname(myna_file), "inputs.json")
-            with open(input_file, "r") as f:
-                input_dict = json.load(f)
-            ref_file = input_dict["GrainOrientationFile"]
 
-            # Get VTK output file
-            output_vtk = os.path.join(
-                os.path.dirname(myna_file),
-                nested_get(input_dict, ["Printing", "PathToOutput"]),
-                nested_get(input_dict, ["Printing", "OutputFile"]) + ".vtk",
-            )
+        # Get reference file from the inputs.json for the case
+        input_file = os.path.join(os.path.dirname(myna_file), "inputs.json")
+        with open(input_file, "r", encoding="utf-8") as f:
+            input_dict = json.load(f)
+        ref_file = input_dict["GrainOrientationFile"]
 
-            # Add RGB coloring
-            export_file = output_vtk.replace(".vtk", "_rgb.vtk")
-            add_rgb_to_vtk(output_vtk, export_file, ref_file)
+        # Get VTK output file
+        output_vtk = os.path.join(
+            os.path.dirname(myna_file),
+            nested_get(input_dict, ["Printing", "PathToOutput"]),
+            nested_get(input_dict, ["Printing", "OutputFile"]) + ".vtk",
+        )
+
+        # Add RGB coloring
+        export_file = output_vtk.replace(".vtk", "_rgb.vtk")
+        add_rgb_to_vtk(output_vtk, export_file, ref_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Over the past few months, we've been transitioning from custom argument parsing in each app to using classes derived from the `myna.core.app.MynaApp`. Somewhere in that transition, the way that the ExaCA apps were written broke and the executable configuration was not being recognized correctly (i.e., including `executable: ExaCA` in the Myna input file for an ExaCA step would throw an error).

This fixes that issue and cleans up the implementation of the `ExaCA(MynaApp)` class in the two ExaCA apps.

