### PR TITLE
db: adds JSON database type for flexible database creation

### DIFF
--- a/examples/MynaJSON/MynaJSON_database_example.json
+++ b/examples/MynaJSON/MynaJSON_database_example.json
@@ -1,0 +1,42 @@
+{
+    "preheat": 298.15,
+    "material": "SS316L",
+    "layer_thickness": 5.0e-05,
+    "P5":
+    {
+        "spot_size": 0.13,
+        "laser_power": 350.0,
+        "51":
+        {
+            "scanpath":
+            {
+                "type": "mynafile",
+                "file": "../Peregrine/simulation/meltpool/P5/0000051.txt"
+            }
+        },
+        "52":
+        {
+            "scanpath":
+            {
+                "type": "mynafile",
+                "file": "../Peregrine/simulation/meltpool/P5/0000052.txt"
+            }
+        },
+        "53":
+        {
+            "scanpath":
+            {
+                "type": "mynafile",
+                "file": "../Peregrine/simulation/meltpool/P5/0000053.txt"
+            }
+        },
+        "54":
+        {
+            "scanpath":
+            {
+                "type": "mynafile",
+                "file": "../Peregrine/simulation/meltpool/P5/0000054.txt"
+            }
+        }
+    }
+}

--- a/examples/solidification_part_json/input.yaml
+++ b/examples/solidification_part_json/input.yaml
@@ -1,0 +1,18 @@
+steps:
+- 3dthesis:
+    class: solidification_part
+    application: thesis
+    configure:
+      res: 50.0e-6
+    execute:
+      np: 8
+data:
+  build:
+    datatype: MynaJSON
+    name: myna_output
+    path: ../MynaJSON/MynaJSON_database_example.json
+    parts:
+      P5:
+        layers: [51,52]
+myna:
+  workspace: ../example-workspace.yaml

--- a/src/myna/database/database_types.py
+++ b/src/myna/database/database_types.py
@@ -11,6 +11,7 @@
 from myna.database.peregrine import PeregrineDB
 from myna.database.peregrine_hdf5 import PeregrineHDF5
 from myna.database.nist_ambench_2022 import AMBench2022
+from myna.database.myna_json import MynaJSON
 
 
 def return_datatype_class(datatype_str):
@@ -45,6 +46,8 @@ def return_datatype_class(datatype_str):
             return PeregrineHDF5()
     elif remove_text_format(datatype_str) in ["ambench2022"]:
         return AMBench2022()
+    elif remove_text_format(datatype_str) in ["mynajson"]:
+        return MynaJSON()
     else:
         print(f"Error: {datatype_str} does not correspond to any implemented database")
         raise NotImplementedError

--- a/src/myna/database/myna_json.py
+++ b/src/myna/database/myna_json.py
@@ -1,0 +1,88 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+"""Database class for a directory with NIST AM-Bench 2022 build data"""
+
+import os
+import json
+from myna.core.db import Database
+from myna.core import metadata
+from myna.core.utils import nested_get
+
+
+class MynaJSON(Database):
+    """Database stored in a JSON dictionary containing Myna data"""
+
+    def __init__(self):
+        Database.__init__(self)
+        self.description = "Myna JSON database"
+
+    def set_path(self, path):
+        """Set the path to the database
+
+        Args:
+          path: filepath to the JSON-containing build data
+        """
+        self.path = path
+        self.path_dir = os.path.dirname(self.path)
+
+    def exists(self):
+        return os.path.exists(self.path)
+
+    def load(self, metadata_type, part=None, layer=None):
+        """Load and return a metadata value from the database"""
+        with open(self.path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        # ==============================================================================
+        # Data values
+        # ==============================================================================
+        if metadata_type == metadata.Material:
+            return nested_get(data, ["material"])
+
+        elif metadata_type == metadata.LayerThickness:
+            return nested_get(data, ["layer_thickness"])  # mm
+
+        elif metadata_type == metadata.Preheat:
+            return nested_get(data, ["preheat"])  # K
+
+        elif metadata_type == metadata.PartIDMap:
+            return nested_get(data, ["print_order"])
+
+        elif metadata_type == metadata.LaserPower:
+            return nested_get(data, [part, "laser_power"])  # W
+
+        elif metadata_type == metadata.SpotSize:
+            return nested_get(data, [part, "spot_size"])  # mm, D4sigma
+
+        # ==============================================================================
+        # File paths
+        # ==============================================================================
+        elif metadata_type == metadata.Scanpath:
+            return self.get_scan_path(data, part, layer)
+
+        elif metadata_type == metadata.STL:
+            return nested_get(data, ["stl"])
+
+        elif metadata_type == metadata.PartIDMap:
+            return nested_get(data, ["part_id_map"])
+
+    def layer_str(self, layernumber):
+        """Return formatted layer number string"""
+        return f"{int(layernumber):07}"
+
+    def get_scan_path(self, data, part, layer):
+        """Returns the scanpath file path, converting or extracting information to a
+        file if necessary"""
+        pathtype = nested_get(data, [part, layer, "scanpath", "type"])
+        if pathtype == "mynafile":
+            return nested_get(data, [part, layer, "scanpath", "file"])
+        else:
+            raise KeyError(
+                f'Invalid entry for "{part}/{layer}/scanpath/type": "{pathtype}"'
+            )


### PR DESCRIPTION
Adds a "custom" database option that accepts a JSON of process data with keys matching the Myna data names defined in `myna.core.metadata.data_class_lookup()`.