### PR TITLE
core: update myna metadata that is written to configured input file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     'h5py',
     'polars',
     'pyebsd @ git+https://github.com/arthursn/pyebsd.git',
-    'scipy']
+    'scipy',
+    'gitpython']
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Adds git repository information to the Myna input and data files. Nothing will be added to the configured input file if the Myna installation is not a Git repository, i.e., does not have a valid `.git` directory.

This adds the `gitpython` dependency to the Python package.

Example of the metadata updated "configure" and new "git" dictionaries:

```yaml
myna:
  workspace: ../example-workspace.yaml
  version: 1.1.0.dev0
  configure: {
    datetime-start: '2025-01-08 12:53:48',
    user-login: cloud,
    input-file: /home/cloud/myna/examples/solidification_part/input.yaml,
    output-file: /home/cloud/myna/examples/solidification_part/ic.yaml,
    datetime-end: '2025-01-08 12:53:48'
  }
  git: {
    commit: 9ba467e84ac6df030824dbf0e9b6b9ff8cc8caa4,
    branch: myna-info-logging,
    origin: 'https://github.com/ORNL-MDF/Myna.git',
    is_dirty: false
  }
```

Partially addresses #20. 