### PR TITLE
AdditiveFOAM app fixup

### DIFF
--- a/src/myna/application/additivefoam/path.py
+++ b/src/myna/application/additivefoam/path.py
@@ -31,6 +31,10 @@ def convert_peregrine_scanpath(filename, export_path, power=1):
     # set the laser power
     df["Power(W)"] = df["Pmod"] * power
 
+    # set spot melts with zero time to have some small dwell time
+    zero_melt_filter = (df["Mode"] == 1) & (df["tParam"] == 0.0)
+    df.loc[zero_melt_filter, "tParam"] = 1e-8
+
     # write the converted path to a new file
     df.to_csv(
         export_path,

--- a/src/myna/application/additivefoam/solidification_region_reduced/template/runCase
+++ b/src/myna/application/additivefoam/solidification_region_reduced/template/runCase
@@ -5,7 +5,7 @@ cd ${0%/*} || exit 1
 # Run AdditiveFOAM solver in parallel
 decomposePar > log.decomposePar 2>&1
 cores=$(foamDictionary -entry numberOfSubdomains -value system/decomposeParDict)
-mpirun -np $cores additiveFoam -parallel > log.additiveFoam 2>&1
+mpirun -np $cores --bind-to none additiveFoam -parallel > log.additiveFoam 2>&1
 
 # Reconstruct ExaCA data into a single file
 reconstructPar > log.reconstructPar 2>&1

--- a/src/myna/application/additivefoam/solidification_region_stl/template/runCase
+++ b/src/myna/application/additivefoam/solidification_region_stl/template/runCase
@@ -5,7 +5,7 @@ cd ${0%/*} || exit 1
 # Run AdditiveFOAM solver in parallel
 decomposePar > log.decomposePar 2>&1
 cores=$(foamDictionary -entry numberOfSubdomains -value system/decomposeParDict)
-mpirun -np $cores additiveFoam -parallel > log.additiveFoam 2>&1
+mpirun -np $cores --bind-to none additiveFoam -parallel > log.additiveFoam 2>&1
 
 # Reconstruct ExaCA data into a single file
 reconstructPar > log.reconstructPar 2>&1


### PR DESCRIPTION
Makes a few changes in the AdditiveFOAM app that were causing inconsistent performance when running AdditiveFOAM through Myna:

- AdditiveFOAM paths no longer have spot melts with zero duration. @colemanjs mentioned that the path indexing logic in AdditiveFOAM could occasionally skip over the spot segments if they had no duration. This is done during conversion from Myna path -> AdditiveFOAM path, so does not affect other apps.
- AdditiveFOAM runs with `mpirun --bind-to none` as the default behavior to avoid oversubscribing resources which can cause slow runtimes