### PR TITLE
update MynaApp default behavior

### DIFF
--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -33,6 +33,7 @@ class MynaApp:
         )
         self.parser.add_argument(
             "--template",
+            default=None,
             type=str,
             help="(str) path to template, if not specified"
             + " then assume default location",
@@ -46,7 +47,10 @@ class MynaApp:
             + " default = False",
         )
         self.parser.add_argument(
-            "--exec", type=str, help=f"(str) Path to {self.name} executable"
+            "--exec",
+            default=None,
+            type=str,
+            help=f"(str) Path to {self.name} executable",
         )
         self.parser.add_argument(
             "--np",

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -79,6 +79,13 @@ class MynaApp:
             help="(flag) if parsed by the app, skip the corresponding"
             + " stage of the component, default = False",
         )
+        self.parser.add_argument(
+            "--mpiexec",
+            default=None,
+            type=str,
+            help="(str) MPI command to prepend to executable if running in parallel",
+        )
+        self.args, _ = self.parser.parse_known_args()
 
     # Check if executable exists
     def check_exe(self, default):

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -85,9 +85,17 @@ class MynaApp:
         )
         self.parser.add_argument(
             "--mpiexec",
-            default=None,
+            default="mpiexec",
             type=str,
-            help="(str) MPI command to prepend to executable if running in parallel",
+            help="(str) MPI executable to prepend for MPI parallel execution"
+            + " (for use with --mpiflags)",
+        )
+        self.parser.add_argument(
+            "--mpiflags",
+            default="",
+            type=str,
+            help="(str) MPI flags to append for MPI parallel execution"
+            + " (for use with --mpiexec)",
         )
         self.args, _ = self.parser.parse_known_args()
 

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -50,7 +50,7 @@ class MynaApp:
         )
         self.parser.add_argument(
             "--np",
-            default=8,
+            default=1,
             type=int,
             help="(int) processors to use per job, will "
             + "correct to the maximum available processors if "


### PR DESCRIPTION
Changes the default behavior of `myna.core.app.MynaApp`:

- Explicitly states default `None` where was not previously specified
- Changes `--np` default to `1`
- Adds `mpiexec` and `mpiflags` arguments that can be used downstream (not currently used, but could be helpful)
- Changes `parser.parse_args()` to `parser.parse_known_args()`. Unknown arguments are ignored.

From discussion in #72.