### PR TITLE
move relevant utilities to `myna.core.utils.filesystem`

### DIFF
--- a/src/myna/application/additivefoam/additivefoam.py
+++ b/src/myna/application/additivefoam/additivefoam.py
@@ -99,7 +99,7 @@ class AdditiveFOAM(MynaApp):
         self.args = self.parser.parse_args()
 
         super().set_procs()
-        super().check_exe(
+        super().validate_executable(
             "additiveFoam",
         )
         self.update_template_path()

--- a/src/myna/application/exaca/exaca.py
+++ b/src/myna/application/exaca/exaca.py
@@ -47,7 +47,7 @@ class ExaCA(MynaApp):
 
         self.args = self.parser.parse_args()
 
-        super().check_exe(
+        super().validate_executable(
             "ExaCA",
         )
 

--- a/src/myna/application/thesis/thesis.py
+++ b/src/myna/application/thesis/thesis.py
@@ -50,7 +50,7 @@ class Thesis(MynaApp):
         self.output_suffix = output_suffix
 
         super().set_procs()
-        super().check_exe("3DThesis")
+        super().validate_executable("3DThesis")
 
         # Initialize layer and part tracking arrays
         self.layers = []

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -80,7 +80,7 @@ class MynaApp:
             + " stage of the component, default = False",
         )
 
-    def check_exe(self, default):
+    def validate_executable(self, default):
         """Check if the specified executable exists and raise error if not"""
         # Get the name of the executable
         exe = self.args.exec

--- a/src/myna/core/utils/__init__.py
+++ b/src/myna/core/utils/__init__.py
@@ -13,3 +13,4 @@ from .conversion import str_to_list
 from .get_argparse_defaults import get_script_call_with_defaults
 from .downsample_to_image import *
 from .get_adjacent_layers import *
+from .filesystem import *

--- a/src/myna/core/utils/filesystem.py
+++ b/src/myna/core/utils/filesystem.py
@@ -8,6 +8,7 @@
 #
 """Tools for file system operations"""
 import os
+import shutil
 from pathlib import Path
 import contextlib
 
@@ -21,3 +22,12 @@ def working_directory(path):
         yield
     finally:
         os.chdir(prev_cwd)
+
+
+def is_executable(executable):
+    """Checks if executable is valid, either as absolute path or accessible through PATH"""
+    full_path = shutil.which(executable, mode=os.X_OK)
+    if full_path is not None:
+        return True
+    else:
+        return False

--- a/src/myna/core/utils/filesystem.py
+++ b/src/myna/core/utils/filesystem.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+"""Tools for file system operations"""
+import os
+from pathlib import Path
+import contextlib
+
+
+@contextlib.contextmanager
+def working_directory(path):
+    """Changes working directory and returns to previous on exit."""
+    prev_cwd = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)

--- a/src/myna/core/workflow/launch_from_peregrine.py
+++ b/src/myna/core/workflow/launch_from_peregrine.py
@@ -11,26 +11,9 @@
 import os
 import subprocess
 import datetime
-import contextlib
-from pathlib import Path
 import yaml
 import shutil
-
-
-@contextlib.contextmanager
-def working_directory(path):
-    """
-    Changes working directory and returns to previous on exit.
-
-    Reference:
-    - https://stackoverflow.com/questions/41742317/how-can-i-change-directory-with-python-pathlib
-    """
-    prev_cwd = Path.cwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(prev_cwd)
+from myna.core.utils import working_directory
 
 
 def launch_from_peregrine(parser):


### PR DESCRIPTION
Moving some tools here to promote reuse within the Myna codebase:

- `working_directory` context manager: useful to have for managing active working directory for applications
- `is_executable` function: while I don't foresee needing to change from `shutil.which` if we want to update in the future, easier to do in one place.