### PR TITLE
add cubit application for meshing ExaCA VTK -> Exodus mesh

### DIFF
--- a/examples/vtk_to_exodus_region/input.yaml
+++ b/examples/vtk_to_exodus_region/input.yaml
@@ -1,0 +1,49 @@
+steps:
+- additivefoam:
+    class: solidification_region_reduced
+    application: additivefoam
+    configure:
+      coarse: 80e-6
+      rx: 0.5e-3
+      ry: 0.5e-3
+      rz: 300.0e-6
+      pad-xy: 0.5e-3
+      pad-z: 0.1e-3
+      pad-sub: 2.5e-3
+      refine-layer: 1
+      refine-region: 1
+    execute:
+      batch: True
+      cores: 2
+- exaca:
+    class: microstructure_region
+    application: exaca
+    executable: ExaCA
+    configure:
+      cell-size: 2.5
+      sub-size: 12.3
+      nd: 250
+      mu: 21
+      std: 3
+    execute:
+      batch: True
+- convert_mesh:
+    class: vtk_to_exodus_region
+    application: cubit
+    execute:
+      cubitpath: /home/cloud/Cubit-17.02
+      downsample: 4
+      mpiexec: /home/cloud/Cubit-17.02/bin/mpiexec
+      np: 2
+data:
+  build:
+    datatype: Peregrine
+    name: myna_output
+    path: ..
+    parts:
+      P5:
+        regions:
+          r1:
+            layers: [51]
+            x: 0.2
+            y: 0.021

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ bnpy = [
     'opencv-python',
     'POT',
 ]
+deer = [
+    'netCDF4',
+]
 
 [project.scripts]
 myna = "myna.core.workflow.all:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ bnpy = [
     'opencv-python',
     'POT',
 ]
-deer = [
+netcdf = [
     'netCDF4',
 ]
 

--- a/src/myna/application/cubit/__init__.py
+++ b/src/myna/application/cubit/__init__.py
@@ -6,4 +6,11 @@
 #
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
+"""
+Defines Myna application behavior for Cubit&reg;-based applications. Cubit&reg;
+is a toolkit for geometry and mesh generation developed by Sandia National
+Laboratories: https://cubit.sandia.gov/
+
+Development was done with `Cubit-17.02` and behavior with other versions is untested.
+"""
 from .cubit import CubitApp

--- a/src/myna/application/cubit/__init__.py
+++ b/src/myna/application/cubit/__init__.py
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+from .cubit import CubitApp

--- a/src/myna/application/cubit/cubit.py
+++ b/src/myna/application/cubit/cubit.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+
+import os
+import shutil
+from myna.core.app.base import MynaApp
+
+
+class CubitApp(MynaApp):
+    def __init__(
+        self,
+        sim_type,
+    ):
+        super().__init__("Cubit")
+        self.simulation_type = sim_type
+        self.parser.add_argument(
+            "--cubitpath",
+            default=None,
+            type=str,
+            help="Path to the root Cubit install directory",
+        )
+        self.args, _ = self.parser.parse_known_args()
+        super().set_procs()
+        self.update_template_path()
+
+    def update_template_path(self):
+        """Updates the template path parameter"""
+        if self.args.template is None:
+            template_path = os.path.join(
+                os.environ["MYNA_APP_PATH"],
+                "cubit",
+                self.simulation_type,
+                "template",
+            )
+            self.args.template = template_path
+
+    def copy_template_to_dir(self, target_dir):
+        """Copies the specified template directory to the specified target directory"""
+        # Ensure directory structure to target exists
+        os.makedirs(os.path.dirname(target_dir), exist_ok=True)
+        if self.args.template is not None:
+            shutil.copytree(self.args.template, target_dir, dirs_exist_ok=True)

--- a/src/myna/application/cubit/cubit.py
+++ b/src/myna/application/cubit/cubit.py
@@ -35,6 +35,27 @@ class CubitApp(MynaApp):
         super().set_procs()
         self.update_template_path()
 
+        # Check that all needed executables are accessible. This overrides the
+        # assumed behavior that each app only has one executable passed through the
+        # `--exec` argument, because the user passes a Cubit install path
+        path_prefix = ""
+        if self.args.cubitpath is not None:
+            path_prefix = os.path.join(self.args.cubitpath, "bin")
+        self.exe_psculpt = os.path.join(path_prefix, "psculpt")
+        self.exe_epu = os.path.join(path_prefix, "epu")
+        original_executable_arg = self.args.exec
+        for executable in [self.exe_psculpt, self.exe_epu]:
+            self.args.exec = executable
+            self.validate_executable(executable)
+        # Set original value back to exec commented out since it is ignored
+        if original_executable_arg is not None:
+            self.args.exec = (
+                f"# (ignored by {self.name}/{self.simulation_type} app) "
+                + original_executable_arg
+            )
+        else:
+            self.args.exec = original_executable_arg
+
     def update_template_path(self):
         """Updates the template path parameter"""
         if self.args.template is None:

--- a/src/myna/application/cubit/cubit.py
+++ b/src/myna/application/cubit/cubit.py
@@ -6,13 +6,19 @@
 #
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
-
+"""Define the application functionality for the base `CubitApp`, which should be
+inherited by all Myna Component applications in this module."""
 import os
 import shutil
 from myna.core.app.base import MynaApp
 
 
 class CubitApp(MynaApp):
+    """Defines Myna application behavior for Cubit&reg;-based applications. Cubit&reg;
+    is a toolkit for geometry and mesh generation developed by Sandia National
+    Laboratories: https://cubit.sandia.gov/
+    """
+
     def __init__(
         self,
         sim_type,

--- a/src/myna/application/cubit/vtk_to_exodus_region/__init__.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/__init__.py
@@ -1,1 +1,17 @@
+"""Application to take an ExaCA VTK output file and convert it to an Exodus finite
+element mesh that is conformal to the grain boundaries.
+
+For example, this application can accept the output of the `exaca/microstructure_region`
+and the defaults assume that use-case.
+
+In addition to the mesh geometry information, this application outputs the following
+block data in the Exodus file that can be accessed by using the `netCDF4` package to
+access the `netCDF4.Dataset().variables` dictionary:
+
+- `id_array`: Grain IDs from the ExaCA VTK file
+- `euler_bunge_zxz_phi1`: Euler angle "phi1" using the Bunge (ZXZ) notation
+- `euler_bunge_zxz_Phi`: Euler angle "Phi" using the Bunge (ZXZ) notation
+- `euler_bunge_zxz_phi2`: Euler angle "phi2" using the Bunge (ZXZ) notation
+"""
+
 from .app import CubitVtkToExodusApp

--- a/src/myna/application/cubit/vtk_to_exodus_region/__init__.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/__init__.py
@@ -1,0 +1,1 @@
+from .app import CubitVtkToExodusApp

--- a/src/myna/application/cubit/vtk_to_exodus_region/app.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/app.py
@@ -6,7 +6,7 @@
 #
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
-
+"""Define the application class functionality for the `CubitVtkToExodusApp` class"""
 import os
 import glob
 import copy
@@ -14,9 +14,12 @@ import shutil
 import json
 import subprocess
 import numpy as np
-import vtk
-from vtk.util.numpy_support import vtk_to_numpy
-from netCDF4 import Dataset
+from vtk import (
+    vtkStructuredPointsReader,
+    vtkExtractVOI,
+)  # pylint: disable=no-name-in-module
+from vtkmodules.util.numpy_support import vtk_to_numpy
+from netCDF4 import Dataset  # pylint: disable=no-name-in-module
 from myna.application.cubit import CubitApp
 from myna.core.utils import working_directory
 from myna.application.exaca import grain_id_to_reference_id, load_grain_ids
@@ -59,7 +62,8 @@ class CubitVtkToExodusApp(CubitApp):
             "--exacainput",
             default="inputs.json",
             type=str,
-            help="(str) name of input file in ExaCA Myna workflow step template that generated the VTK file",
+            help="(str) name of input file in ExaCA Myna workflow step template"
+            + "generated the VTK file",
         )
         self.args, _ = self.parser.parse_known_args()
 
@@ -88,12 +92,12 @@ class CubitVtkToExodusApp(CubitApp):
         """Extract the data object from a VTK file
         containing structured points"""
         # read the VTK structured points file and extract the downsampled data
-        reader = vtk.vtkStructuredPointsReader()
+        reader = vtkStructuredPointsReader()
         reader.SetFileName(vtk_file)
         reader.ReadAllScalarsOn()
         reader.Update()
         structured_points = reader.GetOutput()
-        extractor = vtk.vtkExtractVOI()
+        extractor = vtkExtractVOI()
         extractor.SetInputData(structured_points)
         extractor.SetVOI(structured_points.GetExtent())
         extractor.SetSampleRate(
@@ -171,7 +175,10 @@ class CubitVtkToExodusApp(CubitApp):
                 )
                 returncode = process.wait()
                 if returncode != 0:
-                    error_msg = f"Subprocess exited with return code {returncode}. Check {log_file} for details."
+                    error_msg = (
+                        f"Subprocess exited with return code {returncode}."
+                        + "Check {log_file} for details."
+                    )
                     raise subprocess.SubprocessError(error_msg)
 
                 # If mesh was generated in parallel, combine and clean the split mesh
@@ -185,7 +192,10 @@ class CubitVtkToExodusApp(CubitApp):
                     )
                     returncode = process.wait()
                     if returncode != 0:
-                        error_msg = f"Subprocess exited with return code {returncode}. Check {log_file} for details."
+                        error_msg = (
+                            f"Subprocess exited with return code {returncode}."
+                            + " Check {log_file} for details."
+                        )
                         raise subprocess.SubprocessError(error_msg)
 
                     for tmp_file in tmp_files:

--- a/src/myna/application/cubit/vtk_to_exodus_region/app.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/app.py
@@ -1,0 +1,187 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+
+import os
+import glob
+import copy
+import shutil
+import subprocess
+import numpy as np
+import vtk
+from vtk.util.numpy_support import vtk_to_numpy
+from myna.application.cubit import CubitApp
+from myna.core.utils import working_directory
+
+
+class CubitVtkToExodusApp(CubitApp):
+    def __init__(
+        self,
+        sim_type="vtk_to_exodus",
+    ):
+        super().__init__(sim_type)
+        self.parser.add_argument(
+            "--idarray",
+            default="GrainID",
+            type=str,
+            help="(str) array name of material ids in VTK file to use for conformal meshing",
+        )
+        self.parser.add_argument(
+            "--spn",
+            default="material_ids.spn",
+            type=str,
+            help="output file name containing 1D array of material ids in volume",
+        )
+        self.parser.add_argument(
+            "--downsample",
+            default=5,
+            type=int,
+            help="Sample frequency in XYZ (1 is full dataset)",
+        )
+        self.parser.add_argument(
+            "--sculptflags",
+            default="-S 2 -CS 5 -LI 2 -OI 150 -df 1 -rb 0.2 -A 7 -SS 5",
+            type=str,
+            help="(str) flags to pass to `psculpt` to control mesh generation",
+        )
+        self.args, _ = self.parser.parse_known_args()
+
+        # Check that all needed executables are accessible. This overrides the
+        # assumed behavior that each app only has one executable passed through the
+        # `--exec` argument, because the user passes a Cubit path
+        path_prefix = ""
+        if self.args.cubitpath is not None:
+            path_prefix = os.path.join(self.args.cubitpath, "bin")
+        self.exe_psculpt = os.path.join(path_prefix, "psculpt")
+        self.exe_epu = os.path.join(path_prefix, "epu")
+        original_executable_arg = self.args.exec
+        for executable in [self.exe_psculpt, self.exe_epu]:
+            self.args.exec = executable
+            self.validate_executable(executable)
+        # Set original value back to exec commented out since it is
+        if original_executable_arg is not None:
+            self.args.exec = (
+                f"# (ignored by {self.name}/{self.simulation_type} app) "
+                + original_executable_arg
+            )
+        else:
+            self.args.exec = original_executable_arg
+
+    def get_vtk_file_data(self, vtk_file):
+        """Extract the data object from a VTK file
+        containing structured points"""
+        # read the VTK structured points file and extract the downsampled data
+        reader = vtk.vtkStructuredPointsReader()
+        reader.SetFileName(vtk_file)
+        reader.ReadAllScalarsOn()
+        reader.Update()
+        structured_points = reader.GetOutput()
+        extractor = vtk.vtkExtractVOI()
+        extractor.SetInputData(structured_points)
+        extractor.SetVOI(structured_points.GetExtent())
+        extractor.SetSampleRate(
+            self.args.downsample, self.args.downsample, self.args.downsample
+        )
+        extractor.Update()
+        return extractor.GetOutput()
+
+    def generate_material_id_file(self, vtk_data_array, output_directory):
+        """Convert a VTK file with a material ID field into a Cubit-compatible material
+        id file (.spn) and return dictionary with metadata"""
+
+        # Get unique integers for each id in the `idarray` for .spn file
+        gids = vtk_to_numpy(
+            vtk_data_array.GetPointData().GetArray(self.args.idarray)
+        )  # original list of grain ids
+        spn_ids = copy.copy(gids)  # list to renumber grains starting from 1
+        unique_gids = np.unique(spn_ids)
+        for i, gid in enumerate(unique_gids):
+            spn_ids = np.where(gids == gid, (i + 1) * np.ones_like(gids), spn_ids)
+
+        # Write out spn file from the 1D array
+        spn_file = os.path.join(output_directory, self.args.spn)
+        np.savetxt(
+            spn_file,
+            spn_ids,
+            delimiter=" ",
+            fmt="%d",
+            newline=" ",
+        )
+
+        return
+
+    def mesh_vtk_file(self, vtk_file, exodus_file):
+        """Meshes a VTK file containing a structured points array based on the specified
+        array name (self.args.idarray)"""
+
+        # Pre-process VTK data file
+        case_directory = os.path.dirname(exodus_file)
+        data = self.get_vtk_file_data(vtk_file)
+        nx, ny, nz = data.GetDimensions()
+        self.generate_material_id_file(data, case_directory)
+
+        # Set exodus variables
+        exodus_prefix = os.path.basename(exodus_file).replace(".e", "")
+        sculpt_flags = self.args.sculptflags.split(" ")
+
+        # Change working directory for psculpt, then generate mesh in parallel
+        with working_directory(case_directory):
+            log_file = os.path.join(case_directory, "psculpt.log")
+            with open(log_file, "w", encoding="utf-8") as f:
+
+                sculpt_cmd = [
+                    self.exe_psculpt,
+                    "-isp",
+                    self.args.spn,
+                    "-e",
+                    exodus_prefix,
+                    "-x",
+                    nx,
+                    "-y",
+                    ny,
+                    "-z",
+                    nz,
+                    *sculpt_flags,
+                ]
+                process = self.start_subprocess_with_MPI_args(
+                    [str(x) for x in sculpt_cmd],
+                    stdout=f,
+                    stderr=subprocess.STDOUT,
+                )
+                returncode = process.wait()
+                if returncode != 0:
+                    error_msg = f"Subprocess exited with return code {returncode}. Check {log_file} for details."
+                    raise subprocess.SubprocessError(error_msg)
+
+                # If mesh was generated in parallel, combine and clean the split mesh
+                tmp_files = glob.glob(exodus_prefix + ".e.*")
+                if len(tmp_files) > 1:
+                    combine_cmd = [self.exe_epu, "-p", self.args.np, exodus_prefix]
+                    process = self.start_subprocess(
+                        [str(x) for x in combine_cmd],
+                        stdout=f,
+                        stderr=subprocess.STDOUT,
+                    )
+                    returncode = process.wait()
+                    if returncode != 0:
+                        error_msg = f"Subprocess exited with return code {returncode}. Check {log_file} for details."
+                        raise subprocess.SubprocessError(error_msg)
+
+                    for tmp_file in tmp_files:
+                        os.remove(tmp_file)
+
+                # If mesh was generated in serial, will need to rename the output exodus file
+                elif len(tmp_files) == 1:
+                    shutil.move(tmp_files[0], exodus_prefix + ".e")
+
+    def mesh_all_cases(self):
+        vtk_files = self.settings["data"]["output_paths"][self.last_step_name]
+        exodus_files = self.settings["data"]["output_paths"][self.step_name]
+        for vtk_file, exodus_file in zip(vtk_files, exodus_files):
+            if (not os.path.exists(exodus_file)) or (self.args.overwrite):
+                self.mesh_vtk_file(vtk_file, exodus_file)

--- a/src/myna/application/cubit/vtk_to_exodus_region/execute.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/execute.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+
+from myna.application.cubit.vtk_to_exodus_region import CubitVtkToExodusApp
+
+
+def execute():
+    """Configure all cubit/vtk_to_exodus case directories"""
+    # Create app instance and configure all cases
+    app = CubitVtkToExodusApp()
+    app.mesh_all_cases()
+
+
+if __name__ == "__main__":
+    execute()

--- a/src/myna/application/cubit/vtk_to_exodus_region/execute.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/execute.py
@@ -6,7 +6,7 @@
 #
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
-
+"""Script to run the execute stage of the application when called as a Myna step."""
 from myna.application.cubit.vtk_to_exodus_region import CubitVtkToExodusApp
 
 

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -164,7 +164,7 @@ class MynaApp:
         MPI-related options. **kwargs are passed to `subprocess.Popen`"""
         modified_cmd_args = []
         if self.args.mpiexec is not None:
-            if os.path.basename(self.args.mpiexec) == "srun":
+            if os.path.basename(self.args.mpiexec) in ["srun", "mpirun"]:
                 modified_cmd_args.extend([self.args.mpiexec, "-n", self.args.np, self])
             else:
                 modified_cmd_args.extend([self.args.mpiexec, "-np", self.args.np])

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -7,7 +7,9 @@
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
 import argparse
-import os, shutil
+import os
+import shutil
+import subprocess
 from myna.core.workflow.load_input import load_input
 from myna.core.utils import is_executable
 
@@ -152,3 +154,20 @@ class MynaApp:
             shutil.copytree(self.args.template, case_dir, dirs_exist_ok=True)
         else:
             print(f"Warning: NOT overwriting existing case in: {case_dir}")
+
+    def start_subprocess(self, cmd_args, **kwargs):
+        """Starts a subprocess"""
+        return subprocess.Popen(cmd_args, **kwargs)
+
+    def start_subprocess_with_MPI_args(self, cmd_args, **kwargs):
+        """Starts a subprocess using `Popen` while taking into account the MynaApp
+        MPI-related options. **kwargs are passed to `subprocess.Popen`"""
+        modified_cmd_args = []
+        if self.args.mpiexec is not None:
+            if os.path.basename(self.args.mpiexec) == "srun":
+                modified_cmd_args.extend([self.args.mpiexec, "-n", self.args.np, self])
+            else:
+                modified_cmd_args.extend([self.args.mpiexec, "-np", self.args.np])
+        modified_cmd_args.extend(cmd_args)
+        modified_cmd_args = [str(x) for x in modified_cmd_args]
+        return self.start_subprocess(modified_cmd_args, **kwargs)

--- a/src/myna/core/components/component_class_lookup.py
+++ b/src/myna/core/components/component_class_lookup.py
@@ -51,6 +51,7 @@ def return_step_class(step_name):
         "mesh_part": ComponentPartMesh(),
         "mesh_part_vtk": ComponentPartMeshVTK(),
         "melt_pool_geometry_part": ComponentMeltPoolGeometryPart(),
+        "vtk_to_exodus": ComponentVTKToExodusMesh(),
     }
     try:
         step_class = step_class_lookup[step_name]

--- a/src/myna/core/components/component_class_lookup.py
+++ b/src/myna/core/components/component_class_lookup.py
@@ -51,7 +51,8 @@ def return_step_class(step_name):
         "mesh_part": ComponentPartMesh(),
         "mesh_part_vtk": ComponentPartMeshVTK(),
         "melt_pool_geometry_part": ComponentMeltPoolGeometryPart(),
-        "vtk_to_exodus": ComponentVTKToExodusMesh(),
+        "vtk_to_exodus_part": ComponentVTKToExodusMeshPart(),
+        "vtk_to_exodus_region": ComponentVTKToExodusMeshRegion(),
     }
     try:
         step_class = step_class_lookup[step_name]

--- a/src/myna/core/components/component_mesh.py
+++ b/src/myna/core/components/component_mesh.py
@@ -13,7 +13,7 @@ Available subclasses:
 """
 
 from .component import *
-from myna.core.files.file_vtk import *
+from myna.core.files import FileVTK, FileExodus
 
 
 class ComponentMesh(Component):
@@ -38,3 +38,12 @@ class ComponentPartMeshVTK(ComponentPartMesh):
     def __init__(self):
         ComponentPartMesh.__init__(self)
         self.output_requirement = FileVTK
+
+
+class ComponentVTKToExodusMesh(Component):
+    """Meshing operation"""
+
+    def __init__(self):
+        Component.__init__(self)
+        self.input_requirement = FileVTK
+        self.output_requirement = FileExodus

--- a/src/myna/core/components/component_mesh.py
+++ b/src/myna/core/components/component_mesh.py
@@ -40,10 +40,19 @@ class ComponentPartMeshVTK(ComponentPartMesh):
         self.output_requirement = FileVTK
 
 
-class ComponentVTKToExodusMesh(Component):
-    """Meshing operation"""
+class ComponentVTKToExodusMeshPart(Component):
+    """Meshing operation on a part"""
 
     def __init__(self):
         Component.__init__(self)
         self.input_requirement = FileVTK
         self.output_requirement = FileExodus
+        self.types.append("part")
+
+
+class ComponentVTKToExodusMeshRegion(ComponentVTKToExodusMeshPart):
+    """Meshing operation"""
+
+    def __init__(self):
+        ComponentVTKToExodusMeshPart.__init__(self)
+        self.types.append("region")

--- a/src/myna/core/files/__init__.py
+++ b/src/myna/core/files/__init__.py
@@ -26,3 +26,4 @@ from .file_reduced_solidification import *
 from .file_vtk import *
 from .file_temperature import *
 from .file_melt_pool_geometry import *
+from .file_exodus import *

--- a/src/myna/core/files/file_exodus.py
+++ b/src/myna/core/files/file_exodus.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2024 Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+"""Define a file format class for Exodus mesh output data"""
+
+import os
+from .file import *
+
+
+class FileExodus(File):
+    """File format class for Exodus mesh data"""
+
+    def __init__(self, file):
+        File.__init__(self, file)
+        self.filetype = ".e"
+
+    def file_is_valid(self):
+        """Determines if the associated file is valid.
+
+        Checks if the file extension matches the ".e" filetype.
+
+        Returns:
+           Boolean
+        """
+
+        if (self.filetype is not None) and (
+            os.path.splitext(self.file)[-1] != self.filetype
+        ):
+            return False
+        else:
+            return True


### PR DESCRIPTION
This creates an `application` and the associated `core` functionality for meshing an VTK file into an Exodus mesh file with Cubit.

With the current applications in Myna, the only valid connection is with the VTK output from the ExaCA applications. Therefore, the default `--idarray="GraidID"` is configured to work with the current ExaCA field output in the VTK file. However, a different field could be passed if coming from a different source or if ExaCA changes its output name at some point.

The syntax and default settings for generating the `.spn` file and calling `psculpt` are from scripts from @reverendbedford and Sagar Bhatt, so I've included them as co-authors on the commit that introduces those features.