### PR TITLE
fixup: bnpy now uses MynaApp input file property rather than myna_data

### DIFF
--- a/src/myna/application/bnpy/cluster_solidification/execute.py
+++ b/src/myna/application/bnpy/cluster_solidification/execute.py
@@ -42,7 +42,7 @@ def reduce_thermal_file_to_df(thermal_file):
     return df_reduced, df_training
 
 
-def train_voxel_model(myna_files, thermal_files, sF, gamma):
+def train_voxel_model(myna_files, thermal_files, sF, gamma, input_dir):
     # Load app-specific dependencies
     try:
         import bnpy
@@ -66,7 +66,6 @@ def train_voxel_model(myna_files, thermal_files, sF, gamma):
 
         # Get case myna_data
         myna_data = load_input(os.path.join(case_dir, "myna_data.yaml"))
-        input_dir = os.path.dirname(myna_data["myna"]["input"])
         resource_dir = os.path.join(input_dir, "myna_resources")
 
         # Generate case information from myna_data
@@ -214,7 +213,7 @@ def run_clustering(
     sF,
     gamma,
     overwrite,
-    app,
+    input_dir,
 ):
     # Load app-specific dependencies
     try:
@@ -230,7 +229,6 @@ def run_clustering(
 
     # Get case myna_data
     myna_data = load_input(os.path.join(case_dir, "myna_data.yaml"))
-    input_dir = os.path.dirname(myna_data["myna"]["input"])
     resource_dir = os.path.join(input_dir, "myna_resources")
 
     # Generate case information from myna_data
@@ -383,7 +381,9 @@ def main():
     gamma = 8
     sF = 0.5
     if train_model:
-        train_voxel_model(myna_files, thermal_files, sF, gamma)
+        train_voxel_model(
+            myna_files, thermal_files, sF, gamma, os.path.dirname(app.input_file)
+        )
 
     # Run clustering using trained model
     output_files = []


### PR DESCRIPTION
This is a quick fix to address a break in functionality in the `bnpy` app that resulted from #70.

~It also addresses an edge case in the `get_representative_distribution()` function.~

No app should be relying on the `myna_data["myna"]` entry data, which is currently intended to be a log and not a data store. I'm thinking that, eventually, `myna_data.yaml` should be deprecated as a source of information for cases (if not deleted entirely) to avoid divergence of data between the original input file and the case directories.