### PR TITLE
fixup: correct bnpy edge case in wasserstein representative sampling function

### DIFF
--- a/src/myna/application/bnpy/sample.py
+++ b/src/myna/application/bnpy/sample.py
@@ -67,7 +67,7 @@ def get_representative_distribution(
         B = hist_sample[0].reshape(xt.shape[0])
         wasserstein = ot.emd2(A, B, M)
 
-        if wasserstein != wasserstein_last:
+        if (wasserstein != wasserstein_last) and (wasserstein != 0):
             residue_rel = np.abs((wasserstein_last - wasserstein) / wasserstein)
         else:
             residue_rel = 0.0


### PR DESCRIPTION
Quick fix for bug if Wasserstein distance is zero in sampling function.