### PR TITLE
update changelog and version for 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,42 @@
-## Initial features:
+# Changelog
+
+## 1.1.0
+
+### New features
+
+- New database types: MynaJSON, PeregrineHDF5, AMBench2022
+- Refactor package structure to enable pip install without editable (-e) flag
+
+### Bugfixes and improvements
+
+- Additional info logging during Myna configuration
+- Additional utility features in myna.core
+- Updates to myna.application apps to add functionality and rely more consistently on the MynaApp class
+- Microstructure plotting functions for IPF RGB and Pole Figures added to myna.application.exaca
+- Updates to the Peregrine CLI tool
+- Handle synonymous keys for process parameter entries in for peregrine and peregrine_hdf5 databases
+- Fixed version test
+
+### Minimum dependency version updates
+
+- Minimum supported Python increased to 3.9
+- 3DThesis: commit 547a67b (Nov. 8, 2024) or later
+- ExaCA: commit 08821ef (Aug. 5, 2024) or later
+- AdditiveFOAM: commit b0fa890 (Nov. 12, 2024) or later
+
+## 1.0.0
+
+### Initial features
+
 - Configuration, execution, and syncing for additive manufacturing simulation from database information
 - Support for AdditiveFOAM (heat transfer), 3dThesis (heat transfer), ExaCA (microstructure), bnpy (clustering), and OpenFOAM (mesh generation) applications
 - Support for the Peregrine database and the Peregrine HDF5 public dataset
 - Minimal unit test suite for verifying application usage
 
-## Required dependencies
+### Required dependencies
+
 Those without pip installation include URL. Some dependencies are only used for individual features/applications.
+
 - numpy<2.0
 - PyYAML
 - pandas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "myna"
-version = "1.1.0.dev0"
+version = "1.1.0"
 authors = [
     { name="Gerry Knapp", email="knappgl@ornl.gov" },
     { name="Sam Reeve", email="reevest@ornl.gov"},


### PR DESCRIPTION
Addresses the last open checklist items in #13 and prepares the repository for Myna 1.1.0 release.

No commits should be made between this and the post-release version update to `1.2.0-dev0`