### PR TITLE
fixup: correct duplicate Component name lookup key

### DIFF
--- a/src/myna/core/components/component_class_lookup.py
+++ b/src/myna/core/components/component_class_lookup.py
@@ -34,7 +34,7 @@ def return_step_class(step_name):
         "general": Component(),
         "solidification_part": ComponentSolidificationPart(),
         "solidification_build_region": ComponentSolidificationBuildRegion(),
-        "solidification_region_reduced": ComponentSolidificationRegion(),
+        "solidification_region": ComponentSolidificationRegion(),
         "solidification_part_solidification": ComponentSolidificationPartReduced(),
         "solidification_region_reduced": ComponentSolidificationRegionReduced(),
         "solidification_region_reduced_stl": ComponentSolidificationRegionReducedSTL(),


### PR DESCRIPTION
Noticed this with linting. Technically a bug, but change shouldn't impact current behavior at all since there are no implemented apps for the Component type.