### PR TITLE
add pylint to [dev] dependencies and CI steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,5 +35,10 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - name: Checkout myna
+        uses: actions/checkout@v4
+      - name: Format Check
+        uses: psf/black@stable
+      - name: Analyzing code with pylint
+        uses: |
+          pylint $(git ls-files '*.py') --fail-under=7.25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 dev = [
   'pytest',
   'black>24.10.0',
+  'pylint',
   'licenseheaders']
 exaca = [
   'pyebsd @ git+https://github.com/arthursn/pyebsd.git',


### PR DESCRIPTION
Add `pylint` as a step in the CI workflow.

The current `pylint` summary report yields the following statistics:

```json
{
"statistics": {
        "messageTypeCount": {
            "fatal": 0,
            "error": 54,
            "warning": 231,
            "refactor": 189,
            "convention": 309,
            "info": 0
        },
        "modulesLinted": 107,
        "score": 7.49
    }
}
```

Therefore, the current CI check is set to fail is the `score < 7.25` to allow the current code to pass but to also prevent further degradation of code quality. However, after future efforts to clean up these errors and warnings, I would like to update the CI check to include the [--fail-on](https://pylint.readthedocs.io/en/stable/user_guide/configuration/all-options.html#fail-on) flag and to increment the `--fail-under` score as it improves.

Closes #94 