### PR TITLE
allow for more flexibility in processing material names in databases

### DIFF
--- a/src/myna/core/metadata/data_material.py
+++ b/src/myna/core/metadata/data_material.py
@@ -26,22 +26,65 @@ class Material(BuildMetadata):
     def value_from_database(self):
         """Returns the material name from the associated file
 
-        Returns: str
+        Returns:
+            (str) Myna-formatted material name
         """
         value = self.datatype.load(type(self))
-        value = self.material_name_format(value)
+        value = self.material_name_synonym(value)
         return value
 
-    def material_name_format(self, mat):
+    def material_name_format(self, material):
         """Converts an input material string to consistent format
 
-        Parameters
-        ----------
-        mat : str of material name
+        Args:
+            material : (str) material name
 
         """
 
-        matOut = ""
-        matOut = mat.upper()
-        matOut = matOut.replace(" ", "")
-        return matOut
+        material_formatted = ""
+        material_formatted = material.upper()
+        material_formatted = material_formatted.replace(" ", "")
+        material_formatted = material_formatted.replace("-", "")
+        return material_formatted
+
+    def material_name_synonym(self, material):
+        """Checks if the material name is a known synonym of Myna material names. Myna
+        material names correspond to the files in the `myna.mist_material_data`
+        file names.
+
+        Args:
+            material: (str) material name
+
+        Returns:
+            (str) if the given material is a synonym, then returns the Myna
+            material name, otherwise returns the Myna-formatted input string
+        """
+        # Ensure that the string is formatted as expected
+        # (all upper case, no spaces, no dashes)
+        material_formatted = self.material_name_format(material)
+        synonyms = {
+            "IN625": [
+                "INCONEL625",
+            ],
+            "IN718": [
+                "INCONEL718",
+            ],
+            "SS316H": [
+                "STAINLESSSTEEL316H",
+                "316HSS",
+                "316HSTAINLESSSTEEL",
+            ],
+            "SS316L": [
+                "STAINLESSSTEEL316L",
+                "316LSS",
+                "316LSTAINLESSSTEEL",
+                "316STAINLESSSTEEL",
+                "STAINLESSSTEEL316",
+                "316SS",
+            ],
+        }
+        for key, item in synonyms.items():
+            if material_formatted in item:
+                return key
+
+        return material_formatted


### PR DESCRIPTION
- Preparing for upcoming addition of Pelican, which will have different set of developers and technicians than Peregrine.
- Using "synonym" verbiage to mirror the synonym lookup in the PeregrineDB class