### PR TITLE
add option to suppress verbose output for step class lookup

### DIFF
--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -48,7 +48,7 @@ class MynaApp:
         # e.g., `myna.application.AdditiveFOAM()`
         self.sim_class_obj = None
         try:
-            self.sim_class_obj = return_step_class(self.name)
+            self.sim_class_obj = return_step_class(self.name, verbose=False)
             self.sim_class_obj.apply_settings(
                 self.settings["steps"][self.step_number],
                 self.settings.get("data"),

--- a/src/myna/core/components/component_class_lookup.py
+++ b/src/myna/core/components/component_class_lookup.py
@@ -19,7 +19,7 @@ from .component_melt_pool_geometry import *
 from .component_creep import *
 
 
-def return_step_class(step_name):
+def return_step_class(step_name, verbose=True):
     """Given a string name of a component subclass, return an instance of the subclass
 
     The input file for myna specifies the component class using an input string.
@@ -61,9 +61,12 @@ def return_step_class(step_name):
     try:
         step_class = step_class_lookup[step_name]
     except KeyError as e:
-        print(e)
-        print(f'ERROR: Component name "{step_name}" is not valid. Valid step names:')
-        for key, obj in step_class_lookup.items():
-            print(f'\t- "{key}" ({obj.__class__.__name__})')
+        if verbose:
+            print(e)
+            print(
+                f'ERROR: Component name "{step_name}" is not valid. Valid step names:'
+            )
+            for key, obj in step_class_lookup.items():
+                print(f'\t- "{key}" ({obj.__class__.__name__})')
         raise KeyError(e) from e
     return step_class


### PR DESCRIPTION
- Base `MynaApp` excepts the `KeyError` from this to allow creation of empty `MynaApp()` instances.
- In the case where the exception is handled, useful to be able to suppress the error message to avoid confusion.