### PR TITLE
enable Myna input file in either YAML or JSON format

### DIFF
--- a/src/myna/application/rve/rve_part_center/postprocess.py
+++ b/src/myna/application/rve/rve_part_center/postprocess.py
@@ -10,7 +10,7 @@ from myna.application.rve import RVE
 import os
 import polars as pl
 import yaml
-from myna.core.workflow import config
+from myna.core.workflow import config, write_input
 
 
 def main():
@@ -48,8 +48,7 @@ def main():
             }
 
     # Update the input file
-    with open(app.input_file, "w") as f:
-        yaml.dump(app.settings, f, sort_keys=False, default_flow_style=None, indent=2)
+    write_input(app.settings, app.input_file)
 
     # Re-run myna_config to ensure all directories exist if there is a next step
     config.config(app.input_file)

--- a/src/myna/application/rve/rve_part_center/postprocess.py
+++ b/src/myna/application/rve/rve_part_center/postprocess.py
@@ -9,7 +9,6 @@
 from myna.application.rve import RVE
 import os
 import polars as pl
-import yaml
 from myna.core.workflow import config, write_input
 
 

--- a/src/myna/application/rve/rve_selection/postprocess.py
+++ b/src/myna/application/rve/rve_selection/postprocess.py
@@ -8,7 +8,7 @@
 #
 import os
 import pandas as pd
-from myna.core.workflow import config
+from myna.core.workflow import config, write_input
 from myna.application.rve import RVE
 import numpy as np
 import yaml
@@ -59,8 +59,7 @@ def main():
             }
 
     # Update the input file
-    with open(app.input_file, "w") as f:
-        yaml.dump(app.settings, f, sort_keys=False, default_flow_style=None, indent=2)
+    write_input(app.settings, app.input_file)
 
     # Re-run myna_config to ensure all directories exist if there is a next step
     config.config(app.input_file)

--- a/src/myna/application/rve/rve_selection/postprocess.py
+++ b/src/myna/application/rve/rve_selection/postprocess.py
@@ -11,7 +11,6 @@ import pandas as pd
 from myna.core.workflow import config, write_input
 from myna.application.rve import RVE
 import numpy as np
-import yaml
 
 
 def main():

--- a/src/myna/core/workflow/config.py
+++ b/src/myna/core/workflow/config.py
@@ -11,7 +11,7 @@
 import os
 import yaml
 import copy
-from myna.core.workflow.load_input import load_input
+from myna.core.workflow.load_input import load_input, write_input
 from myna.core.utils import nested_set, nested_get
 from myna.core import components
 from myna.core import metadata
@@ -513,8 +513,8 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
             )
 
             # Write data to case directory
-            with open(os.path.join(case_dir, "myna_data.yaml"), "w") as f:
-                yaml.dump(data_dict_case, f, sort_keys=False, default_flow_style=None)
+            myna_data_file = os.path.join(case_dir, "myna_data.yaml")
+            write_input(data_dict_case, myna_data_file)
 
         # Show the inputs associated with the step
         if step_obj.input_requirement is not None:
@@ -549,5 +549,4 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
         datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    with open(output_file, "w") as f:
-        yaml.dump(settings, f, sort_keys=False, default_flow_style=None)
+    write_input(settings, output_file)

--- a/src/myna/core/workflow/config.py
+++ b/src/myna/core/workflow/config.py
@@ -9,7 +9,6 @@
 """Defines `myna config` functionality"""
 
 import os
-import yaml
 import copy
 from myna.core.workflow.load_input import load_input, write_input
 from myna.core.utils import nested_set, nested_get

--- a/src/myna/core/workflow/launch_from_peregrine.py
+++ b/src/myna/core/workflow/launch_from_peregrine.py
@@ -14,6 +14,7 @@ import datetime
 import yaml
 import shutil
 from myna.core.utils import working_directory
+from myna.core.workflow import write_input
 
 
 def launch_from_peregrine(parser):
@@ -120,8 +121,7 @@ def launch_from_peregrine(parser):
     input_dict["myna"]["workspace"] = workspace
 
     # Export updated input dictionary
-    with open(input_file_configured, "w") as f:
-        yaml.dump(input_dict, f, default_flow_style=False)
+    write_input(input_dict, input_file_configured)
 
     # Set working directory to run all myna scripts
     with working_directory(myna_working_dir):

--- a/src/myna/core/workflow/load_input.py
+++ b/src/myna/core/workflow/load_input.py
@@ -6,6 +6,7 @@
 #
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
+import os
 import json
 import yaml
 
@@ -39,7 +40,7 @@ def load_input(filename):
     """
 
     with open(filename, "r", encoding="utf-8") as f:
-        file_type = filename.split(".")[-1]
+        file_type = os.path.splitext(filename)[1]
         if (file_type.lower() == "yaml") or (file_type.lower() == "myna-workspace"):
             settings = yaml.safe_load(f)
         elif (file_type.lower() == "json") or (
@@ -69,7 +70,7 @@ def write_input(settings, filename):
 
     # Write the Myna input dictionary to a file
     with open(filename, "w", encoding="utf-8") as f:
-        file_type = filename.split(".")[-1]
+        file_type = os.path.splitext(filename)[1]
         if (file_type.lower() == "yaml") or (file_type.lower() == "myna-workspace"):
             yaml.safe_dump(
                 settings, f, sort_keys=False, default_flow_style=None, indent=2

--- a/src/myna/core/workflow/load_input.py
+++ b/src/myna/core/workflow/load_input.py
@@ -29,6 +29,16 @@ def validate_required_input_keys(settings):
     return settings
 
 
+def is_yaml_type(file_type):
+    """Boolean of if file_type if Myna-accepted YAML format"""
+    return (file_type == ".yaml") or (file_type == ".myna-workspace")
+
+
+def is_json_type(file_type):
+    """Boolean of if file_type if Myna-accepted JSON format"""
+    return (file_type == ".json") or (file_type == "myna-workspace-json")
+
+
 def load_input(filename):
     """Load input file into dictionary
 
@@ -41,9 +51,9 @@ def load_input(filename):
 
     with open(filename, "r", encoding="utf-8") as f:
         file_type = os.path.splitext(filename)[1].lower()
-        if (file_type == ".yaml") or (file_type == ".myna-workspace"):
+        if is_yaml_type(file_type):
             settings = yaml.safe_load(f)
-        elif (file_type == ".json") or (file_type == "myna-workspace-json"):
+        elif is_json_type(file_type):
             settings = json.load(f)
         else:
             error_msg = (
@@ -69,11 +79,11 @@ def write_input(settings, filename):
     # Write the Myna input dictionary to a file
     with open(filename, "w", encoding="utf-8") as f:
         file_type = os.path.splitext(filename)[1].lower()
-        if (file_type == ".yaml") or (file_type == ".myna-workspace"):
+        if is_yaml_type(file_type):
             yaml.safe_dump(
                 settings, f, sort_keys=False, default_flow_style=None, indent=2
             )
-        elif (file_type == ".json") or (file_type == "myna-workspace-json"):
+        elif is_json_type(file_type):
             json.dump(settings, f, sort_keys=False, indent=2)
         else:
             error_msg = (

--- a/src/myna/core/workflow/load_input.py
+++ b/src/myna/core/workflow/load_input.py
@@ -31,12 +31,12 @@ def validate_required_input_keys(settings):
 
 def is_yaml_type(file_type):
     """Boolean of if file_type if Myna-accepted YAML format"""
-    return (file_type == ".yaml") or (file_type == ".myna-workspace")
+    return file_type in (".yaml", ".myna-workspace")
 
 
 def is_json_type(file_type):
     """Boolean of if file_type if Myna-accepted JSON format"""
-    return (file_type == ".json") or (file_type == "myna-workspace-json")
+    return file_type in (".json", ".myna-workspace-json")
 
 
 def load_input(filename):

--- a/src/myna/core/workflow/load_input.py
+++ b/src/myna/core/workflow/load_input.py
@@ -40,16 +40,14 @@ def load_input(filename):
     """
 
     with open(filename, "r", encoding="utf-8") as f:
-        file_type = os.path.splitext(filename)[1]
-        if (file_type.lower() == "yaml") or (file_type.lower() == "myna-workspace"):
+        file_type = os.path.splitext(filename)[1].lower()
+        if (file_type == ".yaml") or (file_type == ".myna-workspace"):
             settings = yaml.safe_load(f)
-        elif (file_type.lower() == "json") or (
-            file_type.lower() == "myna-workspace-json"
-        ):
+        elif (file_type == ".json") or (file_type == "myna-workspace-json"):
             settings = json.load(f)
         else:
             error_msg = (
-                f'Unsupported input file type ".{file_type}".'
+                f'Unsupported input file type "{file_type}".'
                 ' Accepted input file formats are ".yaml" and ".json".'
             )
             raise ValueError(error_msg)
@@ -70,18 +68,16 @@ def write_input(settings, filename):
 
     # Write the Myna input dictionary to a file
     with open(filename, "w", encoding="utf-8") as f:
-        file_type = os.path.splitext(filename)[1]
-        if (file_type.lower() == "yaml") or (file_type.lower() == "myna-workspace"):
+        file_type = os.path.splitext(filename)[1].lower()
+        if (file_type == ".yaml") or (file_type == ".myna-workspace"):
             yaml.safe_dump(
                 settings, f, sort_keys=False, default_flow_style=None, indent=2
             )
-        elif (file_type.lower() == "json") or (
-            file_type.lower() == "myna-workspace-json"
-        ):
+        elif (file_type == ".json") or (file_type == "myna-workspace-json"):
             json.dump(settings, f, sort_keys=False, indent=2)
         else:
             error_msg = (
-                f'Unsupported input file type ".{file_type}".'
+                f'Unsupported input file type "{file_type}".'
                 ' Accepted input file formats are ".yaml" and ".json".'
             )
             raise ValueError(error_msg)

--- a/src/myna/core/workflow/load_input.py
+++ b/src/myna/core/workflow/load_input.py
@@ -29,14 +29,35 @@ def validate_required_input_keys(settings):
     return settings
 
 
-def is_yaml_type(file_type):
+def get_validated_input_filetype(filename):
+    """Returns the validate input filetype ("yaml" or "json") and throws an error
+    if the input type is not valid.
+
+    Args:
+        filename: (str) the name or path of the input file"""
+    filetype = os.path.splitext(filename)[1].lower()
+    if is_yaml_type(filetype):
+        return "yaml"
+    elif is_json_type(filetype):
+        return "json"
+    else:
+        error_msg = (
+            f'Unsupported input file type "{filetype}".'
+            " Accepted input file formats are:"
+            '\n- ".yaml" or ".myna-workspace"'
+            '\n- ".json" or ".myna-workspace-json"'
+        )
+        raise ValueError(error_msg)
+
+
+def is_yaml_type(filetype):
     """Boolean of if file_type if Myna-accepted YAML format"""
-    return file_type in (".yaml", ".myna-workspace")
+    return filetype in (".yaml", ".myna-workspace")
 
 
-def is_json_type(file_type):
+def is_json_type(filetype):
     """Boolean of if file_type if Myna-accepted JSON format"""
-    return file_type in (".json", ".myna-workspace-json")
+    return filetype in (".json", ".myna-workspace-json")
 
 
 def load_input(filename):
@@ -50,19 +71,12 @@ def load_input(filename):
     """
 
     with open(filename, "r", encoding="utf-8") as f:
-        file_type = os.path.splitext(filename)[1].lower()
-        if is_yaml_type(file_type):
+        filetype = get_validated_input_filetype(filename)
+        if filetype == "yaml":
             settings = yaml.safe_load(f)
-        elif is_json_type(file_type):
-            settings = json.load(f)
         else:
-            error_msg = (
-                f'Unsupported input file type "{file_type}".'
-                ' Accepted input file formats are ".yaml" and ".json".'
-            )
-            raise ValueError(error_msg)
-
-    return validate_required_input_keys(settings)
+            settings = json.load(f)
+        return validate_required_input_keys(settings)
 
 
 def write_input(settings, filename):
@@ -78,16 +92,10 @@ def write_input(settings, filename):
 
     # Write the Myna input dictionary to a file
     with open(filename, "w", encoding="utf-8") as f:
-        file_type = os.path.splitext(filename)[1].lower()
-        if is_yaml_type(file_type):
+        filetype = get_validated_input_filetype(filename)
+        if filetype == "yaml":
             yaml.safe_dump(
                 settings, f, sort_keys=False, default_flow_style=None, indent=2
             )
-        elif is_json_type(file_type):
-            json.dump(settings, f, sort_keys=False, indent=2)
         else:
-            error_msg = (
-                f'Unsupported input file type "{file_type}".'
-                ' Accepted input file formats are ".yaml" and ".json".'
-            )
-            raise ValueError(error_msg)
+            json.dump(settings, f, sort_keys=False, indent=2)

--- a/src/myna/core/workflow/load_input.py
+++ b/src/myna/core/workflow/load_input.py
@@ -6,7 +6,26 @@
 #
 # License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
 #
+import json
 import yaml
+
+
+def validate_required_input_keys(settings):
+    """Validates the settings dictionary to ensure it has the necessary keys for
+    a Myna input dictionary
+
+    Args:
+        settings: (dict) input settings
+
+    Returns:
+        (dict) validated input settings
+    """
+    # Enforce that main keys exist
+    for key in ["steps", "data", "myna"]:
+        if settings.get(key) is None:
+            settings[key] = {}
+
+    return settings
 
 
 def load_input(filename):
@@ -19,19 +38,49 @@ def load_input(filename):
         settings: dictionary of input file settings
     """
 
-    input_file = filename
-    with open(input_file, "r") as f:
-        file_type = input_file.split(".")[-1]
+    with open(filename, "r", encoding="utf-8") as f:
+        file_type = filename.split(".")[-1]
         if (file_type.lower() == "yaml") or (file_type.lower() == "myna-workspace"):
             settings = yaml.safe_load(f)
+        elif (file_type.lower() == "json") or (
+            file_type.lower() == "myna-workspace-json"
+        ):
+            settings = json.load(f)
         else:
-            print(
-                f'ERROR: Unsupported input file type "{file_type}". Must be .yaml format'
+            error_msg = (
+                f'Unsupported input file type ".{file_type}".'
+                ' Accepted input file formats are ".yaml" and ".json".'
             )
+            raise ValueError(error_msg)
 
-        # Enforce that main keys exist
-        for key in ["steps", "data", "myna"]:
-            if settings.get(key) is None:
-                settings[key] = {}
+    return validate_required_input_keys(settings)
 
-    return settings
+
+def write_input(settings, filename):
+    """Write Myna input dictionary to file
+
+    Args:
+        settings: (dict) Myna input dictionary
+        filename: (str) path to file to write
+    """
+
+    # Ensure that required input keys exist
+    settings = validate_required_input_keys(settings)
+
+    # Write the Myna input dictionary to a file
+    with open(filename, "w", encoding="utf-8") as f:
+        file_type = filename.split(".")[-1]
+        if (file_type.lower() == "yaml") or (file_type.lower() == "myna-workspace"):
+            yaml.safe_dump(
+                settings, f, sort_keys=False, default_flow_style=None, indent=2
+            )
+        elif (file_type.lower() == "json") or (
+            file_type.lower() == "myna-workspace-json"
+        ):
+            json.dump(settings, f, sort_keys=False, indent=2)
+        else:
+            error_msg = (
+                f'Unsupported input file type ".{file_type}".'
+                ' Accepted input file formats are ".yaml" and ".json".'
+            )
+            raise ValueError(error_msg)


### PR DESCRIPTION
This adds detection of YAML vs JSON input files to the `myna.core.workflow.read_input()` functionality. YAML is approximately a superset of JSON, and for the implementation in Myna the two dictionary formats are interchangeable (see https://yaml.org/spec/1.2-old/spec.html#id2759572),

Additionally:

- Adds a `write_input()` function that will detect if JSON or YAML is specified as the output file name.
- Updates references to writing out the input settings dictionary to use the `write_input` function. This adds consistency for the write formatting.

