### PR TITLE
refactor component runner arg list assembly to handle lists of inputs

### DIFF
--- a/src/myna/core/components/component.py
+++ b/src/myna/core/components/component.py
@@ -465,14 +465,14 @@ class Component:
                         return [f"--{key}"]
 
                 # Handle string value
-                if isinstance(value, (str, float, int)):
+                elif isinstance(value, (str, float, int)):
                     if " " in str(value):
                         return ["--" + str(key), get_quoted_str(value)]
                     else:
                         return ["--" + str(key), str(value)]
 
                 # Handle list value
-                if isinstance(value, list):
+                elif isinstance(value, list):
                     return ["--" + str(key), *[str(x) for x in value]]
 
                 # If unhandled, return empty


### PR DESCRIPTION
Cherry-picked feature from #133. 

This simplifies the configure, execute, and postprocess argument handling and adds capability needed to pass list-values as arguments to these steps.

Example:

Myna input file:
```yaml
steps:
- calibrate_additivefoam_heatsource:
    class: single_track_calibration
    application: additivefoam
    configure:
      experiments: experiments.yaml
      nvalues: [0.0, 2.0, 5.0, 7.0, 9.0]
```

Becomes this argument list for the configure step, which is correctly handled by argparse, assuming the `--nvalues` parameter is configured to take multiple entries:
```sh
['--experiments', 'experiments.yaml', '--nvalues', '0.0', '2.0', '5.0', '7.0', '9.0']
```

The previous implementation would have returned the following, which argparse can't handle:
```
['--experiments', 'experiments.yaml', '--nvalues', '"[0.0, 2.0, 5.0, 7.0, 9.0]"']
```