### PR TITLE
fix: reconfigure licenseheader pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,12 +28,9 @@ repos:
     hooks:
       - id: licenseheaders
         name: licenseheaders (src)
+        pass_filenames: false
         args: ["-t", "scripts/bsd-3.tmpl", "--dir", "src", "--ext", ".py"]
-
-
-  - repo: https://github.com/johann-petrak/licenseheaders
-    rev: v0.8.8
-    hooks:
       - id: licenseheaders
         name: licenseheaders (tests)
+        pass_filenames: false
         args: ["-t", "scripts/bsd-3.tmpl", "--dir", "tests", "--ext", ".py"]


### PR DESCRIPTION
- `pass_filenames` is set to False to allow licenseheaders to control file discovery
- single hook with multiple steps versus two separate hooks is likely not an issue, but does simplify the pre-commit file and could have been causing the same files to be processed twice

Closes #157.

Should help resolve failing CI in #156.

I tested and haven't been able to reproduce the issue of deleted file contents locally. 