### PR TITLE
fix: correct syntax in examples using mpiflags

### DIFF
--- a/examples/cluster_solidification/input_rve.yaml
+++ b/examples/cluster_solidification/input_rve.yaml
@@ -39,7 +39,7 @@ steps:
         batch: True
         np: 24
         mpiexec: mpirun
-        mpiargs: --bind-to none
+        mpiflags: --bind-to none
 data:
   build:
     datatype: Peregrine

--- a/examples/microstructure_region/input.yaml
+++ b/examples/microstructure_region/input.yaml
@@ -15,11 +15,11 @@ steps:
       exaca-mesh: 10.0e-6
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
     execute:
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
 - exaca:
     class: microstructure_region
     application: exaca

--- a/examples/microstructure_region_slice/input.yaml
+++ b/examples/microstructure_region_slice/input.yaml
@@ -16,7 +16,7 @@ steps:
       batch: True
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
 - exaca:
     class: microstructure_region_slice
     application: exaca

--- a/examples/rve_part_center/input.yaml
+++ b/examples/rve_part_center/input.yaml
@@ -21,7 +21,7 @@ steps:
       overwrite: True
       np: 16
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
 data:
   build:
     datatype: Peregrine

--- a/examples/solidification_region_reduced/input.yaml
+++ b/examples/solidification_region_reduced/input.yaml
@@ -16,7 +16,7 @@ steps:
     execute:
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
 data:
   build:
     datatype: Peregrine

--- a/examples/solidification_region_reduced_stl/input.yaml
+++ b/examples/solidification_region_reduced_stl/input.yaml
@@ -16,11 +16,11 @@ steps:
       exaca-mesh: 10.0e-6
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
     execute:
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
 data:
   build:
     datatype: Peregrine

--- a/examples/vtk_to_exodus_region/input.yaml
+++ b/examples/vtk_to_exodus_region/input.yaml
@@ -16,7 +16,7 @@ steps:
       batch: True
       np: 2
       mpiexec: mpirun
-      mpiargs: --bind-to none
+      mpiflags: --bind-to none
 - exaca:
     class: microstructure_region
     application: exaca

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -204,7 +204,7 @@ class MynaApp:
         if self.args.mpiargs is not None:
             if self.args.mpiexec is not None:
                 raise ValueError(
-                    "--mpiargs (deprecated) may not be used with --mpiexec"
+                    "--mpiargs (deprecated input) may not be used with --mpiexec"
                 )
             if self.args.mpiflags is not None:
                 warnings.warn(
@@ -216,7 +216,7 @@ class MynaApp:
             for flag in ["-n", "--n", "-np", "--np"]:
                 if flag in args:
                     warnings.warn(
-                        f"--mpiargs (deprecated) settings will overwrite --{flag} settings"
+                        f"--mpiargs (deprecated input) settings will overwrite {flag} input"
                     )
                     np_flag_index = args.index(flag)
                     self.args.np = int(args[np_flag_index + 1])

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -202,11 +202,22 @@ class MynaApp:
 
         TODO: Remove this function in next release"""
         if self.args.mpiargs is not None:
+            if self.args.mpiexec is not None:
+                raise ValueError(
+                    "--mpiargs (deprecated) may not be used with --mpiexec"
+                )
+            if self.args.mpiflags is not None:
+                warnings.warn(
+                    "--mpiargs (deprecated) settings will overwrite --mpiflags settings"
+                )
             args = self.args.mpiargs.split(" ")
             self.args.mpiexec = args[0].replace('"', "").replace("'", "")
             del args[0]
             for flag in ["-n", "--n", "-np", "--np"]:
                 if flag in args:
+                    warnings.warn(
+                        f"--mpiargs (deprecated) settings will overwrite --{flag} settings"
+                    )
                     np_flag_index = args.index(flag)
                     self.args.np = int(args[np_flag_index + 1])
                     del args[np_flag_index + 1]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -43,6 +43,7 @@ def test_configure():
     examples = [
         "cluster_solidification",
         "melt_pool_geometry_part",
+        "melt_pool_geometry_part_pelican",
         "microstructure_region",
         "microstructure_region_slice",
         "openfoam_meshing",
@@ -51,9 +52,12 @@ def test_configure():
         "solidification_part",
         "solidification_part_hdf5",
         "solidification_part_json",
+        "solidification_part_pelican",
         "solidification_region_reduced",
         "solidification_region_reduced_stl",
         "temperature_part",
+        "temperature_part_pvd",
+        "vtk_to_exodus_region",
     ]
 
     # This file will be in myna/tests


### PR DESCRIPTION
Closes #160.

Summary of changes:

- Changes `mpiargs` -> `mpiflags` in examples to ensure correct behavior
- Update error handling in `MynaApp._mpiargs_to_current()`
- Updates the examples folders to test during the `test_configure.py` tests to give better coverage