### PR TITLE
feat(core/app): adds MynaApp class functions to assist with workflow elements

### DIFF
--- a/src/myna/application/adamantine/temperature_part_pvd/app.py
+++ b/src/myna/application/adamantine/temperature_part_pvd/app.py
@@ -84,20 +84,20 @@ class AdamantineTemperatureApp(AdamantineApp):
 
     def parse_configure_arguments(self):
         """Check for arguments relevant to the configure step and update app settings"""
-        self.parser.add_argument(
+        self.register_argument(
             "--mesh-substrate-depth",
             default=1e-3,
             type=float,
             help="Depth of the substrate to mesh below the scan path, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--mesh-substrate-xy-pad",
             default=0.5e-3,
             type=float,
             help="XY padding of the substrate relative to the scan "
             "path bounds, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--mesh-size-factor",
             default=1,
             type=float,
@@ -105,7 +105,7 @@ class AdamantineTemperatureApp(AdamantineApp):
             "In x and y, the mesh size is equal to the factor * nominal spot size. "
             "In z, the mesh size is equal to the factor * layer thickness",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--write-frequency-factor",
             default=5,
             type=float,
@@ -113,26 +113,26 @@ class AdamantineTemperatureApp(AdamantineApp):
             "Output frequency is equal to the"
             "(factor * nominal spot size) / median scan speed",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--convection-heat-transfer-coef",
             default=100.0,
             type=float,
             help="Heat transfer coefficient for the solid & liquid "
             "convective boundary condition (W m^-2)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--convection-temperature-infty",
             default=300.0,
             type=float,
             help="Temperature at x -> infinity for convective boundary condition (K)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--radiation-temperature-infty",
             default=300.0,
             type=float,
             help="Temperature at x -> infinity for radiative boundary condition (K)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--courant",
             default=0.1,
             type=float,

--- a/src/myna/application/additivefoam/solidification_region_reduced/app.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced/app.py
@@ -478,7 +478,7 @@ class AdditiveFOAMRegionReduced(AdditiveFOAM):
 
     def postprocess(self):
         """Postprocesses all cases"""
-        _, _, files_are_valid = self.component.get_output_files()
+        _, _, files_are_valid = self.get_output_file_status()
         if not all(files_are_valid):
             mynafiles = self.settings["data"]["output_paths"][self.step_name]
             for mynafile in mynafiles:

--- a/src/myna/application/additivefoam/solidification_region_reduced/app.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced/app.py
@@ -34,65 +34,65 @@ class AdditiveFOAMRegionReduced(AdditiveFOAM):
     def parse_configure_arguments(self):
         """Check for arguments relevant to the configure step and update app settings"""
         # Parse app-specific arguments
-        self.parser.add_argument(
+        self.register_argument(
             "--exaca-mesh",
             default=2.5e-6,
             type=float,
             help="Mesh size for the ExaCA simulations, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--rx",
             default=1e-3,
             type=float,
             help="(float) width of region along X-axis, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--ry",
             default=1e-3,
             type=float,
             help="(float) width of region along Y-axis, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--rz",
             default=1e-3,
             type=float,
             help="(float) depth of region along Z-axis, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--pad-xy",
             default=2e-3,
             type=float,
             help="(float) size of single-refinement mesh region around"
             + " the double-refined region in XY, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--pad-z",
             default=1e-3,
             type=float,
             help="(float) size of single-refinement mesh region around"
             + " the double-refined region in Z, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--pad-sub",
             default=1e-3,
             type=float,
             help="(float) size of coarse mesh cubic region below"
             + " the refined regions in Z, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--coarse",
             default=640e-6,
             type=float,
             help="(float) size of fine mesh, in meters",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--refine-layer",
             default=5,
             type=int,
             help="(int) number of region mesh refinement"
             + " levels in layer (each level halves coarse mesh)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--refine-region",
             default=1,
             type=int,

--- a/src/myna/application/additivefoam/solidification_region_reduced_stl/app.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced_stl/app.py
@@ -27,17 +27,19 @@ class AdditiveFOAMRegionReducedSTL(AdditiveFOAMRegionReduced):
         self.class_name = "solidification_region_reduced_stl"
         self.stl_mesh_dict_name = "stl_mesh_dict.yaml"
 
-    def configure(self):
-        """Configure all cases for the application"""
-        # Check for arguments relevant to the configure step
-        self.parse_configure_arguments()  # args from the AdditiveFOAMRegionReduced app
+    def parse_configure_arguments(self):
         self.parser.add_argument(
             "--scale",
             default=0.001,
             type=float,
             help="Multiple by which to scale the STL file dimensions (default = 0.001, mm -> m)",
         )
-        self.parse_known_args()
+        super().parse_configure_arguments()
+
+    def configure(self):
+        """Configure all cases for the application"""
+        # Check for arguments relevant to the configure step
+        self.parse_configure_arguments()
 
         # Get list of expected output files and iterate through the cases
         mynafiles = self.settings["data"]["output_paths"][self.step_name]

--- a/src/myna/application/additivefoam/solidification_region_reduced_stl/app.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced_stl/app.py
@@ -28,7 +28,7 @@ class AdditiveFOAMRegionReducedSTL(AdditiveFOAMRegionReduced):
         self.stl_mesh_dict_name = "stl_mesh_dict.yaml"
 
     def parse_configure_arguments(self):
-        self.parser.add_argument(
+        self.register_argument(
             "--scale",
             default=0.001,
             type=float,

--- a/src/myna/application/cubit/cubit.py
+++ b/src/myna/application/cubit/cubit.py
@@ -22,13 +22,17 @@ class CubitApp(MynaApp):
     def __init__(self):
         super().__init__()
         self.app_type = "cubit"
+
+    def parse_shared_arguments(self):
         self.parser.add_argument(
             "--cubitpath",
             default=None,
             type=str,
             help="Path to the root Cubit install directory",
         )
-        self.parse_known_args()
+
+    def _validate_cubit_executables(self):
+        """Check that Cubit executables are accessible for the parsed options."""
 
         # Check that all needed executables are accessible. This overrides the
         # assumed behavior that each app only has one executable passed through the
@@ -49,3 +53,13 @@ class CubitApp(MynaApp):
             )
         else:
             self.args.exec = original_executable_arg
+
+    def parse_configure_arguments(self):
+        self.parse_shared_arguments()
+        self.parse_known_args()
+        self._validate_cubit_executables()
+
+    def parse_execute_arguments(self):
+        self.parse_shared_arguments()
+        self.parse_known_args()
+        self._validate_cubit_executables()

--- a/src/myna/application/cubit/cubit.py
+++ b/src/myna/application/cubit/cubit.py
@@ -24,7 +24,7 @@ class CubitApp(MynaApp):
         self.app_type = "cubit"
 
     def parse_shared_arguments(self):
-        self.parser.add_argument(
+        self.register_argument(
             "--cubitpath",
             default=None,
             type=str,

--- a/src/myna/application/cubit/vtk_to_exodus_region/app.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/app.py
@@ -34,32 +34,32 @@ class CubitVtkToExodusApp(CubitApp):
         self.class_name = "vtk_to_exodus"
 
     def parse_execute_arguments(self):
-        self.parser.add_argument(
+        self.register_argument(
             "--field",
             default="GrainID",
             type=str,
             help="(str) field name of material ids in ExaCA VTK file to use for "
             + "conformal meshing",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--spn",
             default="material_ids.spn",
             type=str,
             help="output file name containing 1D array of material ids in volume",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--downsample",
             default=5,
             type=int,
             help="Sample frequency in XYZ (1 is full dataset)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--sculptflags",
             default="-S 2 -CS 5 -LI 2 -OI 150 -df 1 -rb 0.2 -A 7 -SS 5",
             type=str,
             help="(str) flags to pass to `psculpt` to control mesh generation",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--exacainput",
             default="inputs.json",
             type=str,

--- a/src/myna/application/cubit/vtk_to_exodus_region/app.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/app.py
@@ -32,6 +32,8 @@ class CubitVtkToExodusApp(CubitApp):
     def __init__(self):
         super().__init__()
         self.class_name = "vtk_to_exodus"
+
+    def parse_execute_arguments(self):
         self.parser.add_argument(
             "--field",
             default="GrainID",
@@ -64,7 +66,7 @@ class CubitVtkToExodusApp(CubitApp):
             help="(str) name of input file in ExaCA Myna workflow step template"
             + "generated the VTK file",
         )
-        self.parse_known_args()
+        super().parse_execute_arguments()
 
     def get_vtk_file_data(self, vtk_file):
         """Extract the data object from a VTK file
@@ -158,13 +160,7 @@ class CubitVtkToExodusApp(CubitApp):
                     stdout=f,
                     stderr=subprocess.STDOUT,
                 )
-                returncode = process.wait()
-                if returncode != 0:
-                    error_msg = (
-                        f"Subprocess exited with return code {returncode}."
-                        + "Check {log_file} for details."
-                    )
-                    raise subprocess.SubprocessError(error_msg)
+                self.wait_for_process_success(process)
 
                 # If mesh was generated in parallel, combine and clean the split mesh
                 tmp_files = glob.glob(exodus_prefix + ".e.*")
@@ -175,13 +171,7 @@ class CubitVtkToExodusApp(CubitApp):
                         stdout=f,
                         stderr=subprocess.STDOUT,
                     )
-                    returncode = process.wait()
-                    if returncode != 0:
-                        error_msg = (
-                            f"Subprocess exited with return code {returncode}."
-                            + " Check {log_file} for details."
-                        )
-                        raise subprocess.SubprocessError(error_msg)
+                    self.wait_for_process_success(process)
 
                     for tmp_file in tmp_files:
                         os.remove(tmp_file)
@@ -239,3 +229,8 @@ class CubitVtkToExodusApp(CubitApp):
         for vtk_file, exodus_file in zip(vtk_files, exodus_files):
             if (not os.path.exists(exodus_file)) or (self.args.overwrite):
                 self.mesh_vtk_file(vtk_file, exodus_file)
+
+    def execute(self):
+        """Execute all cubit/vtk_to_exodus_region cases."""
+        self.parse_execute_arguments()
+        self.mesh_all_cases()

--- a/src/myna/application/cubit/vtk_to_exodus_region/execute.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/execute.py
@@ -12,10 +12,9 @@ from myna.application.cubit.vtk_to_exodus_region import CubitVtkToExodusApp
 
 
 def execute():
-    """Configure all cubit/vtk_to_exodus case directories"""
-    # Create app instance and configure all cases
+    """Execute all cubit/vtk_to_exodus case directories."""
     app = CubitVtkToExodusApp()
-    app.mesh_all_cases()
+    app.execute()
 
 
 if __name__ == "__main__":

--- a/src/myna/application/deer/creep_timeseries_region/app.py
+++ b/src/myna/application/deer/creep_timeseries_region/app.py
@@ -60,7 +60,7 @@ class CreepTimeseriesRegionDeerApp(DeerApp):
             type=float,
             help="(float) load in Newtons",
         )
-        self.parse_known_args()
+        super().parse_configure_arguments()
 
     def configure_case(self, case_dir, exodus_file):
         """Configure a single case
@@ -121,6 +121,7 @@ class CreepTimeseriesRegionDeerApp(DeerApp):
 
     def execute(self):
         """Run all cases for the Myna step"""
+        self.parse_execute_arguments()
         exodus_files = self.settings["data"]["output_paths"][self.last_step_name]
         csv_files = self.settings["data"]["output_paths"][self.step_name]
         processes = []
@@ -133,24 +134,11 @@ class CreepTimeseriesRegionDeerApp(DeerApp):
                 if self.args.batch:
                     processes.append(process)
                 else:
-                    returncode = process.wait()
-                    if returncode != 0:
-                        error_msg = (
-                            f"Subprocess exited with return code {returncode}."
-                            + " Check case log files for details."
-                        )
-                        raise subprocess.SubprocessError(error_msg)
+                    self.wait_for_process_success(process)
 
         # Wait for batched jobs to finish
         if self.args.batch:
-            for process in processes:
-                returncode = process.wait()
-                if returncode != 0:
-                    error_msg = (
-                        f"Subprocess exited with return code {returncode}. "
-                        + "Check case log files for details."
-                    )
-                    raise subprocess.SubprocessError(error_msg)
+            self.wait_for_all_process_success(processes)
 
         # Copy output to the Myna format
         # Deer output has the following column names (units):

--- a/src/myna/application/deer/creep_timeseries_region/app.py
+++ b/src/myna/application/deer/creep_timeseries_region/app.py
@@ -48,13 +48,13 @@ class CreepTimeseriesRegionDeerApp(DeerApp):
 
     def parse_configure_arguments(self):
         """Check for arguments relevant to the configure step and update app settings"""
-        self.parser.add_argument(
+        self.register_argument(
             "--loaddir",
             default="z",
             type=str,
             help='(str) loading direction ("x" , "y", "z")',
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--load",
             default="100",
             type=float,

--- a/src/myna/application/deer/deer.py
+++ b/src/myna/application/deer/deer.py
@@ -19,10 +19,19 @@ class DeerApp(MynaApp):
     def __init__(self):
         super().__init__()
         self.app_type = "deer"
+
+    def parse_shared_arguments(self):
         self.parser.add_argument(
             "--moosepath",
             default=None,
             type=str,
             help="Path to the root Moose install directory",
         )
+
+    def parse_configure_arguments(self):
+        self.parse_shared_arguments()
+        self.parse_known_args()
+
+    def parse_execute_arguments(self):
+        self.parse_shared_arguments()
         self.parse_known_args()

--- a/src/myna/application/deer/deer.py
+++ b/src/myna/application/deer/deer.py
@@ -21,7 +21,7 @@ class DeerApp(MynaApp):
         self.app_type = "deer"
 
     def parse_shared_arguments(self):
-        self.parser.add_argument(
+        self.register_argument(
             "--moosepath",
             default=None,
             type=str,

--- a/src/myna/core/app/_argument_registrar.py
+++ b/src/myna/core/app/_argument_registrar.py
@@ -1,0 +1,126 @@
+#
+# Copyright (c) Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+"""Private helper for idempotent argparse registration in `MynaApp`."""
+
+
+class _ArgumentRegistrar:
+    """Register argparse options while rejecting conflicting re-definitions."""
+
+    def __init__(self, parser):
+        self.parser = parser
+        self._argument_registry = {}
+
+    def _infer_dest(self, option_strings, positional_name, kwargs):
+        """Infer the argparse destination in the same style as argparse."""
+
+        if "dest" in kwargs:
+            return kwargs["dest"]
+        if option_strings:
+            long_options = [
+                option for option in option_strings if option.startswith("--")
+            ]
+            preferred = long_options[0] if long_options else option_strings[0]
+            return preferred.lstrip("-").replace("-", "_")
+        return positional_name
+
+    def _normalize_argument_signature(self, *name_or_flags, **kwargs):
+        """Return the registration fields used to compare duplicates."""
+
+        option_strings = tuple(
+            sorted(
+                option
+                for option in name_or_flags
+                if isinstance(option, str) and option.startswith("-")
+            )
+        )
+        positional_names = [
+            name
+            for name in name_or_flags
+            if isinstance(name, str) and not name.startswith("-")
+        ]
+        positional_name = positional_names[0] if positional_names else None
+        return {
+            "option_strings": option_strings,
+            "dest": self._infer_dest(option_strings, positional_name, kwargs),
+            "action": kwargs.get("action", "store"),
+            "nargs": kwargs.get("nargs"),
+            "const": kwargs.get("const"),
+            "default": kwargs.get("default"),
+            "type": kwargs.get("type"),
+            "choices": tuple(kwargs.get("choices")) if kwargs.get("choices") else None,
+            "required": kwargs.get("required", False),
+            "metavar": kwargs.get("metavar"),
+        }
+
+    def _get_argument_identities(self, signature):
+        """Return registry keys for an argument registration.
+
+        Optional arguments are keyed by option string so shared aliases map back to
+        one action. Positional arguments do not have option strings, so `dest` is the
+        stable identity used to detect collisions.
+        """
+
+        if signature["option_strings"]:
+            return [("option", option) for option in signature["option_strings"]]
+        return [("dest", signature["dest"])]
+
+    def _raise_argument_registration_error(
+        self,
+        identity,
+        existing_entry,
+        new_signature,
+    ):
+        """Raise a descriptive error for an invalid duplicate registration."""
+
+        identity_type, identity_value = identity
+        identity_label = (
+            f"option '{identity_value}'"
+            if identity_type == "option"
+            else f"dest '{identity_value}'"
+        )
+        raise ValueError(
+            "Conflicting argument registration for "
+            f"{identity_label}. "
+            f"Existing signature: {existing_entry['signature']}; "
+            f"new signature: {new_signature}."
+        )
+
+    def register(self, *name_or_flags, **kwargs):
+        """Register an argument while allowing exact duplicate re-registration."""
+
+        signature = self._normalize_argument_signature(*name_or_flags, **kwargs)
+        identities = self._get_argument_identities(signature)
+        existing_entries = [
+            (identity, self._argument_registry[identity])
+            for identity in identities
+            if identity in self._argument_registry
+        ]
+
+        if existing_entries:
+            reference_identity, reference_entry = existing_entries[0]
+            for identity, entry in existing_entries[1:]:
+                if entry is not reference_entry:
+                    self._raise_argument_registration_error(
+                        identity,
+                        entry,
+                        signature,
+                    )
+            if reference_entry["signature"] == signature:
+                return reference_entry["action"]
+            self._raise_argument_registration_error(
+                reference_identity,
+                reference_entry,
+                signature,
+            )
+
+        action = self.parser.add_argument(*name_or_flags, **kwargs)
+        entry = {"action": action, "signature": signature}
+        for identity in identities:
+            self._argument_registry[identity] = entry
+        return action

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -194,6 +194,24 @@ class MynaApp:
             )
         return self.component.get_output_files()
 
+    def get_step_output_paths(self, step_name=None):
+        """Return configured output file paths for a workflow step."""
+        if step_name is None:
+            step_name = self.step_name
+        try:
+            return self.settings["data"]["output_paths"][step_name]
+        except KeyError as e:
+            raise KeyError(
+                f"Could not find output paths for step '{step_name}'. "
+                f"Missing key {e} in settings dictionary structure."
+            ) from e
+
+    def get_case_dirs(self, step_name=None, output_paths=None):
+        """Return case directories associated with workflow output files."""
+        if output_paths is None:
+            output_paths = self.get_step_output_paths(step_name)
+        return [os.path.dirname(x) for x in output_paths]
+
     def parse_known_args(self):
         """Parse known command line arguments to update self.args and apply
         any corrections"""

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -18,6 +18,7 @@ import warnings
 from pathlib import Path
 import docker
 from docker.models.containers import Container
+from myna.core.app._argument_registrar import _ArgumentRegistrar
 from myna.core.workflow.load_input import load_input
 from myna.core.utils import is_executable, get_quoted_str
 from myna.core.components import return_step_class
@@ -60,14 +61,15 @@ class MynaApp:
         self.parser = argparse.ArgumentParser(
             description="Configure input files for specified Myna cases"
         )
-        self.parser.add_argument(
+        self._argument_registrar = _ArgumentRegistrar(self.parser)
+        self.register_argument(
             "--template",
             default=None,
             type=str,
             help="(str) path to template, if not specified"
             + " then assume default location",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--overwrite",
             dest="overwrite",
             default=False,
@@ -75,13 +77,13 @@ class MynaApp:
             help="force regeneration of each run and overwrite of any existing data,"
             + " default = False",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--exec",
             default=None,
             type=str,
             help="(str) Path to executable",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--np",
             default=1,
             type=int,
@@ -89,7 +91,7 @@ class MynaApp:
             + "correct to the maximum available processors if "
             + "set too large",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--maxproc",
             default=None,
             type=int,
@@ -97,14 +99,14 @@ class MynaApp:
             + "correct to the maximum available processors if "
             + "set too large",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--batch",
             dest="batch",
             default=False,
             action="store_true",
             help="(flag) run jobs in parallel",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--skip",
             dest="skip",
             default=False,
@@ -112,27 +114,27 @@ class MynaApp:
             help="(flag) if parsed by the app, skip the corresponding"
             + " stage of the component, default = False",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--mpiexec",
             default=None,
             type=str,
             help="(str) MPI executable to prepend for MPI parallel execution"
             + " (for use with --mpiflags)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--mpiflags",
             default=None,
             type=str,
             help="(str) MPI flags to append for MPI parallel execution"
             + " (for use with --mpiexec)",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--env",
             default=None,
             type=str,
             help="(str) file to source to set up environment for executable",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--docker-image",
             default=None,
             type=str,
@@ -140,7 +142,7 @@ class MynaApp:
             "MPI options, and environment file will be applied within "
             "the docker container",
         )
-        self.parser.add_argument(
+        self.register_argument(
             "--mpiargs",
             default=None,
             type=str,
@@ -221,6 +223,13 @@ class MynaApp:
         if self.args.skip:
             print(f"- Skipping part of step {self.step_name}")
             sys.exit()
+
+    def register_argument(self, *name_or_flags, **kwargs):
+        """Register an argument with duplicate detection."""
+        return self._argument_registrar.register(
+            *name_or_flags,
+            **kwargs,
+        )
 
     def parse_configure_arguments(self):
         """Register arguments used by the configure stage.

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -186,6 +186,14 @@ class MynaApp:
             except KeyError:
                 return obj
 
+    def get_output_file_status(self):
+        """Return the component output file paths, existence, and validity flags."""
+        if self.component is None:
+            raise ValueError(
+                f"MynaApp {self.name} does not have an associated component class."
+            )
+        return self.component.get_output_files()
+
     def parse_known_args(self):
         """Parse known command line arguments to update self.args and apply
         any corrections"""

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -221,6 +221,30 @@ class MynaApp:
         Subclasses can override this method and call `self.parse_known_args()`.
         """
 
+    def configure(self):
+        """Configure the application workflow step.
+
+        Subclasses should override this method instead of implementing workflow logic
+        in the stage wrapper scripts.
+        """
+        raise NotImplementedError
+
+    def execute(self):
+        """Execute the application workflow step.
+
+        Subclasses should override this method instead of implementing workflow logic
+        in the stage wrapper scripts.
+        """
+        raise NotImplementedError
+
+    def postprocess(self):
+        """Postprocess the application workflow step.
+
+        Subclasses should override this method instead of implementing workflow logic
+        in the stage wrapper scripts.
+        """
+        raise NotImplementedError
+
     def _mpiargs_to_current(self):
         """Function to convert the deprecated `--mpiargs` option to the current
         `--mpiexec`, `--np`, and `--mpiflags` options

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -196,6 +196,31 @@ class MynaApp:
             print(f"- Skipping part of step {self.step_name}")
             sys.exit()
 
+    def parse_configure_arguments(self):
+        """Register arguments used by the configure stage.
+
+        Subclasses can override this method and call `self.parse_known_args()`.
+        """
+
+    def parse_execute_arguments(self):
+        """Register arguments used by the execute stage.
+
+        Subclasses can override this method and call `self.parse_known_args()`.
+        """
+
+    def parse_shared_arguments(self):
+        """Register arguments shared across multiple app stages.
+
+        Subclasses can override this method and call `self.parse_known_args()` in the
+        relevant stage-specific parse methods.
+        """
+
+    def parse_postprocess_arguments(self):
+        """Register arguments used by the postprocess stage.
+
+        Subclasses can override this method and call `self.parse_known_args()`.
+        """
+
     def _mpiargs_to_current(self):
         """Function to convert the deprecated `--mpiargs` option to the current
         `--mpiexec`, `--np`, and `--mpiflags` options

--- a/tests/test_app_argument_parsing.py
+++ b/tests/test_app_argument_parsing.py
@@ -1,0 +1,160 @@
+#
+# Copyright (c) Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+import sys
+
+import pytest
+
+from myna.application.cubit.cubit import CubitApp
+from myna.application.deer.deer import DeerApp
+from myna.core.app.base import MynaApp
+
+
+def _count_option_actions(parser, option_string):
+    return sum(option_string in action.option_strings for action in parser._actions)
+
+
+def test_register_argument_skips_duplicate_option_registration(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = MynaApp()
+
+    app.register_argument(
+        "--demo",
+        default="value",
+        type=str,
+        help="Demo parser option for regression coverage",
+    )
+    app.register_argument(
+        "--demo",
+        default="value",
+        type=str,
+        help="Demo parser option for regression coverage",
+    )
+    app.parse_known_args()
+
+    assert _count_option_actions(app.parser, "--demo") == 1
+    assert app.args.demo == "value"
+
+
+def test_register_argument_rejects_conflicting_option_redefinitions(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = MynaApp()
+
+    app.register_argument(
+        "--demo",
+        default="value",
+        type=str,
+        help="Demo parser option for regression coverage",
+    )
+
+    with pytest.raises(ValueError, match="option '--demo'"):
+        app.register_argument(
+            "--demo",
+            default="different",
+            type=str,
+            help="Demo parser option for regression coverage",
+        )
+
+
+def test_register_argument_deduplicates_across_hooks(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = MynaApp()
+
+    app.register_argument(
+        "--demo",
+        default="value",
+        type=str,
+        help="Demo parser option for regression coverage",
+    )
+    app.register_argument(
+        "--demo",
+        default="value",
+        type=str,
+        help="Demo parser option for regression coverage",
+    )
+    app.parse_known_args()
+
+    assert _count_option_actions(app.parser, "--demo") == 1
+    assert app.args.demo == "value"
+
+
+def test_register_argument_rejects_shadowing_base_arguments(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = MynaApp()
+
+    with pytest.raises(ValueError, match="option '--np'"):
+        app.register_argument(
+            "--np",
+            default=2,
+            type=int,
+            help="Conflicting processor override",
+        )
+
+
+def test_register_argument_skips_duplicate_positional_registration(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = MynaApp()
+
+    app.register_argument("demo_positional")
+    app.register_argument("demo_positional")
+
+    positional_actions = [
+        action for action in app.parser._actions if action.dest == "demo_positional"
+    ]
+    assert len(positional_actions) == 1
+
+
+def test_register_argument_rejects_conflicting_positional_dest_redefinitions(
+    monkeypatch,
+):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = MynaApp()
+
+    app.register_argument("demo_positional")
+
+    with pytest.raises(ValueError, match="dest 'demo_positional'"):
+        app.register_argument("demo_positional", nargs="?")
+
+
+@pytest.mark.parametrize(
+    "stage_calls",
+    [
+        ("parse_execute_arguments", "parse_configure_arguments"),
+        ("parse_configure_arguments", "parse_execute_arguments"),
+        ("parse_execute_arguments", "parse_execute_arguments"),
+    ],
+)
+def test_deer_stage_parsers_are_idempotent(monkeypatch, stage_calls):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    app = DeerApp()
+
+    for stage_call in stage_calls:
+        getattr(app, stage_call)()
+
+    assert _count_option_actions(app.parser, "--moosepath") == 1
+    assert app.args.moosepath is None
+
+
+@pytest.mark.parametrize(
+    "stage_calls",
+    [
+        ("parse_execute_arguments", "parse_configure_arguments"),
+        ("parse_configure_arguments", "parse_execute_arguments"),
+        ("parse_execute_arguments", "parse_execute_arguments"),
+    ],
+)
+def test_cubit_stage_parsers_are_idempotent(monkeypatch, stage_calls):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitApp()
+
+    for stage_call in stage_calls:
+        getattr(app, stage_call)()
+
+    assert _count_option_actions(app.parser, "--cubitpath") == 1
+    assert app.args.cubitpath is None


### PR DESCRIPTION
This is a precursor to a larger PR that will address #159 and adds necessary placeholder and utility functions to remove repetitive workflow-related code from the various apps and enforce/suggest a more consistent structure between apps.

These functions are applied in existing apps that already use the MynaApp structure.

This adds:

- `MynaApp` placeholder functions for configure, execute, and postprocess stage functionality
- `MynaApp` placeholder functions for adding any associated `argparse` options with configure, execute, and postprocess, as well as any options shared across all stages
- `MynaApp` function to return the output directories (i.e., case directories) associated with a given step, as well as the expected output files and their status.