### PR TITLE
chore: add issue templates for bug reports, feature requests, and work items

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,28 +4,19 @@
 
 ## Steps to reproduce
 <!-- List the exact commands, inputs, or workflow steps needed to reproduce the issue. -->
+<!-- Describe how often this happens and whether you have noticed any pattern. -->
 
 
-## Actual behavior
-<!-- Describe what actually happened, including errors, crashes, incorrect output, or other unexpected results. -->
+## Observed behavior
+<!-- Describe what happened when following the steps above, including any errors, crashes, incorrect output, or other unexpected results. -->
 
 
 ## Expected behavior
 <!-- Describe what you expected to happen when following the same steps. -->
 
 
-## Reproducibility
-<!-- Describe how often this happens and whether you have noticed any pattern. -->
-
-- Reproduces: always / sometimes / once
-- Frequency or pattern:
-
 ## Environment
 <!-- Describe the setup where the issue occurred, including OS, shell, Python version, Myna version, install method, and any other relevant environment details. -->
-
-
-## Additional context
-<!-- Add supporting details such as logs, screenshots, workarounds, or links to related issues. -->
 
 
 ## Possible solution

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+## Summary
+<!-- Briefly describe the bug and why it matters. -->
+
+
+## Steps to reproduce
+<!-- List the exact commands, inputs, or workflow steps needed to reproduce the issue. -->
+
+1.
+2.
+3.
+
+## Actual behavior
+<!-- Describe what actually happened, including errors, crashes, incorrect output, or other unexpected results. -->
+
+
+## Expected behavior
+<!-- Describe what you expected to happen when following the same steps. -->
+
+
+## Reproducibility
+<!-- Describe how often this happens and whether you have noticed any pattern. -->
+
+- Reproduces: always / sometimes / once
+- Frequency or pattern:
+
+## Environment
+<!-- Describe the setup where the issue occurred, including OS, shell, Python version, Myna version, install method, and any other relevant environment details. -->
+
+
+## Additional context
+<!-- Add supporting details such as logs, screenshots, workarounds, or links to related issues. -->
+
+
+## Possible solution
+<!-- If you have ideas about how this bug could be fixed, describe them here. This could include potential changes to the code, configuration, or workflow that might resolve the issue. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,9 +5,6 @@
 ## Steps to reproduce
 <!-- List the exact commands, inputs, or workflow steps needed to reproduce the issue. -->
 
-1.
-2.
-3.
 
 ## Actual behavior
 <!-- Describe what actually happened, including errors, crashes, incorrect output, or other unexpected results. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+## Summary
+<!-- Briefly describe the feature being requested and the outcome it should enable. -->
+
+
+## Problem or opportunity
+<!-- Describe the user problem, limitation, or opportunity that motivates this request. -->
+<!-- Explain what is difficult, missing, or inefficient today. -->
+
+
+## Proposed capability
+<!-- Describe the feature or behavior you would like to see added. -->
+<!-- Focus on what the feature should do rather than how it must be implemented. -->
+
+
+## Use case
+<!-- Describe the workflow, scenario, or user need this feature would support. -->
+<!-- Include who would use it and when it would be helpful. -->
+
+
+## Alternatives considered
+<!-- Describe any current workarounds, alternative approaches, or existing behavior that partially addresses this need. -->
+
+
+## Success criteria
+<!-- Describe what would make this request successful from a user or workflow perspective. -->
+<!-- Focus on observable outcomes rather than implementation details. -->
+
+
+## Additional context
+<!-- Add any supporting details such as examples, mockups, screenshots, related issues, or external references. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,27 +4,14 @@
 
 ## Problem or opportunity
 <!-- Describe the user problem, limitation, or opportunity that motivates this request. -->
-<!-- Explain what is difficult, missing, or inefficient today. -->
+<!-- Explain what is difficult, missing, or inefficient today, and include any supporting context such as examples, screenshots, related issues, or external references if helpful. -->
 
 
 ## Proposed capability
-<!-- Describe the feature or behavior you would like to see added. -->
-<!-- Focus on what the feature should do rather than how it must be implemented. -->
+<!-- Describe the feature or behavior you would like to see added, and include any current workarounds or alternatives considered. -->
+<!-- Focus on the outcome the feature should enable rather than how it must be implemented. -->
 
 
-## Use case
-<!-- Describe the workflow, scenario, or user need this feature would support. -->
-<!-- Include who would use it and when it would be helpful. -->
-
-
-## Alternatives considered
-<!-- Describe any current workarounds, alternative approaches, or existing behavior that partially addresses this need. -->
-
-
-## Success criteria
+## Acceptance criteria
 <!-- Describe what would make this request successful from a user or workflow perspective. -->
 <!-- Focus on observable outcomes rather than implementation details. -->
-
-
-## Additional context
-<!-- Add any supporting details such as examples, mockups, screenshots, related issues, or external references. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,6 +1,6 @@
 ## Summary
-<!-- Briefly describe the requested development work as concisely as possible. -->
-<!-- This may be a refactor, performance improvement, or chore. -->
+<!-- Briefly describe the development task being requested. -->
+<!-- This may be a refactor, performance improvement, chore, etc. -->
 
 
 ## Background

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -1,0 +1,18 @@
+## Summary
+<!-- Briefly describe the requested development work as concisely as possible. -->
+<!-- This may be a refactor, performance improvement, or chore. -->
+
+
+## Background
+<!-- Provide the relevant background information that explains why this work is being requested. -->
+<!-- This could include current-state context, maintenance needs, bottlenecks, dependencies, or the problem being addressed. -->
+
+
+## Proposed solution
+<!-- Describe the proposed solution or approach to address the need described above. -->
+<!-- This could include refactor direction, optimization strategy, or chore / maintenance work needed to achieve the goal. -->
+
+
+## Acceptance criteria
+<!-- List the conditions that must be met for this work to be considered complete and successful. -->
+<!-- These should be specific, testable, and measurable criteria covering behavior, maintainability, performance targets, or completion outcomes as relevant. -->

--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -14,5 +14,5 @@
 
 
 ## Acceptance criteria
-<!-- List the conditions that must be met for this work to be considered complete and successful. -->
-<!-- These should be specific, testable, and measurable criteria covering behavior, maintainability, performance targets, or completion outcomes as relevant. -->
+<!-- List the conditions that must be met to close this issue as complete. -->
+<!-- Criteria should be specific and measurable, e.g., "Myna is able to read .XYZ format of input file". Checklist format is preferred. -->


### PR DESCRIPTION
## Summary

Adds three GitHub issue templates for common contribution flows: bug reports, feature requests, and work items. These templates standardize the information collected at issue creation time so triage and follow-up work can happen with clearer, more actionable context.

## Related issues

- Closes #150 

## Details

This is a `chore` change focused on repository workflow and contribution quality. The new templates introduce structured prompts for:

- bug reports, including reproduction steps, actual vs expected behavior, reproducibility, environment details, and possible solutions
- feature requests, including the motivating problem, proposed capability, use case, alternatives considered, and success criteria
- tasks, including background, proposed solution, and acceptance criteria for development-focused tasks

These additions improve consistency in issue intake and make it easier to gather the context needed for prioritization, implementation planning, and follow-up.

## Impact

- Overall risk level of changes is `Low`, because this change only adds repository issue templates and does not affect application code or runtime behavior.

## Testing strategy

- [ ] The CI test suite covers this change.
- [x] Manual testing performed for this change. If so, please describe.

Manual validation focused on reviewing each template for completeness, clarity, and alignment with the repository’s contribution workflow. This included confirming that the sections collect the intended information for bug reporting, feature requests, and development work intake.