### PR TITLE
fix(core): refer to current python intrepretter directly in workflow

### DIFF
--- a/src/myna/core/components/component.py
+++ b/src/myna/core/components/component.py
@@ -9,6 +9,7 @@
 """Base class for workflow components"""
 
 import os
+import sys
 from pathlib import Path
 from typing import Literal
 import subprocess
@@ -55,7 +56,7 @@ class Component:
             "configure.py",
         )
         if os.path.exists(configure_path):
-            cmd = ["python", configure_path]
+            cmd = [sys.executable, configure_path]
             cmd.extend(self.get_step_args_list("configure"))
             cmd = self.cmd_preformat(cmd)
             print(f"myna run: {cmd=}")
@@ -71,7 +72,7 @@ class Component:
             "execute.py",
         )
         if os.path.exists(execute_path):
-            cmd = ["python", execute_path]
+            cmd = [sys.executable, execute_path]
             cmd.extend(self.get_step_args_list("execute"))
             cmd = self.cmd_preformat(cmd)
             print(f"myna run: {cmd=}")
@@ -87,7 +88,7 @@ class Component:
             "postprocess.py",
         )
         if os.path.exists(postprocess_path):
-            cmd = ["python", postprocess_path]
+            cmd = [sys.executable, postprocess_path]
             cmd.extend(self.get_step_args_list("postprocess"))
             cmd = self.cmd_preformat(cmd)
             print(f"myna run: {cmd=}")


### PR DESCRIPTION
## Summary
<!-- Provide a concise description of this pull request and what it changes. -->
This switched to use `sys.executable` instead of `"python`" as the `subprocess` launch argument for component workflow steps.

## Related issues
<!-- Link to the relevant issue(s) (e.g., "Closes #12" or "Related to #13"). -->
<!-- This helps automatically link this pull request to the issue in GitHub. -->
<!-- If no related issues, check the box below to indicate you have considered this. -->

- [x] No related issues.


## Details
<!-- Describe the context for this change based on the selected pull request type. -->
<!--
Pull request types are defined in `CONTRIBUTING.md`. For the more common types, please include the relevant details below:
- Bug fix (`fix`): summarize the bug, how it was reproduced, the root cause, and why this fix addresses it.
- Feature (`feat`): describe the user problem, the capability added, and the workflow or use case it enables.
- Performance (`perf`): describe the bottleneck or performance problem and the improvement this change is intended to deliver.
- Refactor (`refactor`): describe the maintainability or architectural problem being addressed and the rationale for the refactor.
- Chore (`chore`): describe the project, tooling, documentation, configuration, or maintenance goal this change addresses.
-->
<!-- Explain how this change was implemented and which parts of the application were changed. -->
<!-- Focus on the behavior change, structural change, optimization strategy, or workflow outcome rather than just a file list. -->

Due to the variety of ways that Python can be launched (system installation, virtual envs, various venv managers), it is possible that `python` in the script environment is different from `python` used to launch the script.

This fixes an issue that showed up in the Peregrine CLI where the incorrect interpreter was being used when running in a `uv` environment. This is particularly an issue when using `uv` for environment management, since the environment may not be active on the command line, unlike `conda` or other managers where the environment must be activated before using the CLI tools.

## Impact
<!-- Describe any impact on functionality, workflows, performance, maintainability, or user experience. -->
<!-- If behavior is intended to remain unchanged, state that explicitly. -->
<!-- If this is a performance change, include measured impact here or in Testing strategy details. -->

- Overall risk level of changes (High / Medium / Low) and why: This is a low risk change, as it doesn't change program or user behavior.


## Testing strategy
<!-- Explain how this change was tested or validated to ensure the intended result was achieved without introducing regressions. -->
<!--
Testing environment details should generally include:
- OS/shell
- Python version
- Install method (`uv`/`pip`/`Docker`)
- Command or workflow tested
- External application version if relevant
- Hardware specs if performance-sensitive
-->

- [x] The CI test suite covers this change.
- [x] Manual testing performed for this change. If so, please describe.

I manually tested this change using the `myna config/run` workflow in the `solidification_part` example, as well as the `myna launch_peregrine` CLI workflow. Testing was done on a Windows 11 OS using `uv` installation of Myna.