### PR TITLE
fix(workflow): fail when run outputs are missing

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -155,8 +155,11 @@ Branch names use:
 ```
 
 Examples: `docs/agent-harness`, `fix/database-paths`, `feat(cli): add dry-run flag`.
-Complete `.github/pull_request_template.md` and state behavior impact, risk, and
-testing strategy.
+When asked to draft or open a pull request, first inspect and complete
+`.github/pull_request_template.md`. Preserve the template headings and checklist, and
+state behavior impact, risk, and testing strategy. If the requested PR body is scoped
+to a subset of commits while the branch contains other commits, state that scope
+explicitly in the body.
 
 ## Security and Data Handling
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -176,3 +176,7 @@ testing strategy.
 - Public behavior changes, compatibility risks, or known gaps are called out.
 - Docs and examples are updated when commands, inputs, outputs, or extension points
   change.
+- If code changes touch `src/myna/core/workflow/`, `src/myna/core/components/`,
+  `src/myna/core/app/`, `src/myna/core/context.py`, `src/myna/database/`, CLI behavior,
+  app extension patterns, or subsystem boundaries, update `ARCHITECTURE.md` and
+  relevant developer docs, or state why no docs update was needed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,3 +47,9 @@ Describe the testing strategy for this change and include any relevant details a
 If the change is covered by the CI test suite, state that explicitly.
 If manual testing was performed, describe the testing process and results.
 -->
+
+
+## Checklist
+
+- [ ] Architecture/docs impact considered. Updated `ARCHITECTURE.md`, developer docs,
+      and/or ADRs where needed, or explained why not.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,4 +52,4 @@ If manual testing was performed, describe the testing process and results.
 ## Checklist
 
 - [ ] Architecture/docs impact considered. Updated `ARCHITECTURE.md`, developer docs,
-      and/or ADRs where needed, or explained why not.
+      and/or ADRs where needed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- Last verified: 2026-06-01 during the documentation-harness update
+- Last verified: 2026-06-01 during the workflow-context update
 - Audience: maintainers, contributors, and coding agents
 - Scope: describes current architecture; does not replace API docs or user docs
 
@@ -44,6 +44,7 @@ The main user workflows are:
 | `uv.lock` | Locked `uv` dependency graph | Commit updates when dependency declarations change |
 | `src/myna/` | Python package source | Runtime code lives here |
 | `src/myna/core/` | Workflow orchestration, components, file abstractions, metadata, app base helpers, utilities | Prefer generic workflow behavior here |
+| `src/myna/core/context.py` | Explicit workflow context shared by orchestration, components, app wrappers, metadata, and sync helpers | Prefer this over workflow-specific environment variables for new shared behavior |
 | `src/myna/core/workflow/` | `config`, `run`, `sync`, `status`, and input loading stages | CLI entrypoint delegates here |
 | `src/myna/core/components/` | Workflow component classes and lookup table | Component string keys are user-facing compatibility surface |
 | `src/myna/core/files/` | Output file classes and validation/sync value extraction | Add new output formats here |
@@ -99,10 +100,15 @@ On import, `src/myna/core/__init__.py` sets:
 - `MYNA_INSTALL_PATH` to the installed `myna` package root;
 - `MYNA_APP_PATH` to the installed `myna/application` directory.
 
-Workflow commands set additional runtime environment variables, including `MYNA_INPUT`,
-`MYNA_CONFIG_INPUT`, `MYNA_RUN_INPUT`, `MYNA_SYNC_INPUT`, `MYNA_STEP_NAME`,
-`MYNA_STEP_CLASS`, and `MYNA_STEP_INDEX`. The `*_INPUT` variables are marked in code as
-future deprecation targets; prefer `MYNA_INPUT` for new shared behavior.
+Workflow run and sync state is carried through `myna.core.context.WorkflowContext`.
+This context includes the active input file, current step, step class, step index, and
+previous-step information. `MynaApp` reads that explicit context first. It still falls
+back to legacy `MYNA_*` environment variables so direct stage-script invocation remains
+compatible.
+
+`myna config` still sets `MYNA_INPUT` and the deprecated `MYNA_CONFIG_INPUT` while it
+extracts metadata. New shared workflow code should prefer `WorkflowContext`,
+`MynaApp` attributes, or `get_workflow_input_file()` over direct `os.environ` reads.
 
 ## Main Concepts and Domain Model
 
@@ -117,8 +123,8 @@ future deprecation targets; prefer `MYNA_INPUT` for new shared behavior.
   `data_requirements`, `input_requirement`, `output_requirement`, and hierarchical
   `types` such as `build`, `build_region`, `part`, `region`, and `layer`.
 - **Application wrapper**: Tool-specific code under `src/myna/application/<app>/<class>/`
-  that may provide `configure.py`, `execute.py`, and `postprocess.py` stages. Wrappers
-  commonly use `myna.core.app.MynaApp`.
+  that may provide `configure.py`, `execute.py`, and `postprocess.py` stage modules.
+  Wrappers commonly use `myna.core.app.MynaApp`.
 - **Database adapter**: A subclass of `myna.core.db.Database` under
   `src/myna/database/` that loads metadata and syncs outputs for a supported data
   source.
@@ -148,7 +154,7 @@ flowchart TD
     Component --> Cases[case directories and myna_data.yaml]
     CLI --> Run[myna run]
     Run --> ComponentRun[Component.run_component]
-    ComponentRun --> AppStages[application configure/execute/postprocess scripts]
+    ComponentRun --> AppStages[application configure/execute/postprocess modules]
     AppStages --> Outputs[component output files]
     CLI --> Sync[myna sync]
     Sync --> FileValidation[file validation]
@@ -160,9 +166,11 @@ the input file, resolves the database adapter with `return_datatype_class`, extr
 component metadata requirements, creates case directories, writes per-case
 `myna_data.yaml`, records expected output paths, and writes the configured input. For
 `run`, Myna reloads the input before each step, applies step settings to a component,
-sets step environment variables, and runs the available app-stage scripts. For `sync`,
-Myna validates component outputs and delegates supported sync behavior to the selected
-database adapter.
+and calls available app-stage modules in-process through `Component.run_component`.
+Stage command-line arguments from the input file are still exposed through `sys.argv`
+while each stage runs, preserving `argparse`-based app wrappers. For `sync`, Myna
+validates component outputs and delegates supported sync behavior to the selected
+database adapter while providing the active input file through `WorkflowContext`.
 
 ## Dependency Boundaries
 
@@ -303,4 +311,4 @@ local executable configuration, and keep machine-specific values out of shared e
 | External application version coverage is mostly documented in prose and CI container behavior | Local users may not know which exact tool version failed | Add per-application troubleshooting notes as failures are reported |
 | API docs are generated but not committed | A fresh checkout needs generation before strict MkDocs parity with CI | Keep `scripts/group_docs.py` documented and run it before docs-build checks |
 | LazyDocs API generation is verified in CI on Python 3.10, not all newer local Python versions | Local docs builds can fail before checking authored docs content | Use a Python 3.10 environment for docs-generation parity with CI |
-| Deprecated environment variables remain in workflow code | New code could depend on names marked for future removal | Prefer `MYNA_INPUT` in new code and track deprecation in release notes when removal is planned |
+| Legacy workflow environment fallbacks remain for direct app-stage invocation | Compatibility fallbacks could tempt new code to reintroduce hidden workflow state | Prefer `WorkflowContext`, `MynaApp` attributes, or `get_workflow_input_file()` in new code |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,7 @@ The main user workflows are:
 | `docs/decisions/` | Lightweight architecture decision records | Add records for non-obvious architectural choices |
 | `scripts/group_docs.py` | Generates and groups LazyDocs API documentation | CI runs this before `mkdocs build --strict` |
 | `scripts/check_dev_tools.py` | Checks local development tool availability and writable caches | Run first in new agent or container shells |
-| `scripts/check_docs_harness.py` | Validates required agent-harness docs and links | Runs in pre-commit and CI |
+| `scripts/check_docs_harness.py` | Validates required agent-harness docs, links, and architecture-doc updates for sensitive code changes | Runs in pre-commit and CI |
 | `.pre-commit-config.yaml` | Local quality hooks | Includes Ruff, codespell, license headers, and docs harness check |
 | `.github/workflows/CI.yml` | Package build, default tests, pylint, API docs, MkDocs, and external-app example CI | External-app job runs in a container |
 | `.github/workflows/pre-commit.yml` | Pre-commit CI | Runs hooks on pull requests |
@@ -241,7 +241,7 @@ Common validation commands:
 | External examples | `uv run pytest -m "examples and not parallel"` | Requires external tools and example fixtures |
 | Generate API docs | `uv run scripts/group_docs.py` | Writes ignored `docs/api-docs/` |
 | Build docs | `uv run mkdocs build --strict` | Run after API docs generation for parity with CI |
-| Docs harness | `uv run python scripts/check_docs_harness.py` | Verifies required agent docs and links |
+| Docs harness | `uv run python scripts/check_docs_harness.py` | Verifies required agent docs, links, and architecture-doc updates for sensitive code changes |
 | Pre-commit | `uv run pre-commit run --all-files` | May require network the first time hooks install |
 
 CI behavior:

--- a/docs/decisions/.pages
+++ b/docs/decisions/.pages
@@ -1,4 +1,5 @@
 title: Architecture Decisions
 nav:
   - index.md
+  - 0001-workflow-context.md
   - 0000-template.md

--- a/docs/decisions/0001-workflow-context.md
+++ b/docs/decisions/0001-workflow-context.md
@@ -1,0 +1,49 @@
+---
+title: Workflow Context
+---
+
+# 0001: Use Explicit Workflow Context for App Stage Execution
+
+## Status
+
+Accepted
+
+## Context
+
+Myna workflows pass ordered step information from `myna run` and `myna sync` into
+components, application wrappers, metadata helpers, and database sync code. Previously,
+some of this state was communicated through mutable `MYNA_*` environment variables and
+app-stage Python subprocesses. That made workflow state implicit and worked against the
+object-oriented structure used by components and `MynaApp` subclasses.
+
+Application stage files such as `configure.py`, `execute.py`, and `postprocess.py` are
+still useful extension points and are commonly implemented with `argparse`.
+
+## Decision
+
+Workflow run and sync state is carried by `myna.core.context.WorkflowContext`.
+`Component.run_component()` imports available app-stage modules and calls their stage
+function, or `main()`, in-process. During each stage call, Myna temporarily populates
+`sys.argv` with the configured stage arguments so existing `argparse`-based wrappers
+continue to behave as command-line stages.
+
+`MynaApp` reads explicit context first and falls back to legacy `MYNA_*` environment
+variables for direct script invocation compatibility. New code should use
+`WorkflowContext`, `MynaApp` attributes, or `get_workflow_input_file()` rather than
+direct `os.environ` reads for workflow state.
+
+## Consequences
+
+Workflow state is explicit in normal orchestration, easier to test, and no longer
+requires environment-variable mutation between app-stage subprocesses. Existing stage
+modules remain compatible if they expose the expected callable and parse arguments with
+`argparse`.
+
+Direct invocation of app-stage scripts can still rely on legacy environment-variable
+fallbacks, but that path is compatibility behavior rather than the preferred extension
+pattern.
+
+## Validation
+
+- `uv run pytest`
+- `tests/test_workflow_context.py`

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -112,33 +112,40 @@ input file, just provide an arbitrary name for the application, e.g., "test".
 ## Developing new applications
 
 Once a new component is implemented, you will have to implement a corresponding
-application (app) to use with `myna run`. Applications consist of up to three scripts:
+application (app) to use with `myna run`. Applications consist of up to three stage
+modules:
 
-1. `config.py`: Script that configures the files within each Myna case folder generated
-during `myna config`. At the end of this script, each case folder should be a valid
-case directory for whatever model is being run.
-2. `execute.py`: Script that executes the model for each case.
-3. `postprocess.py`: Script that converts the output of the model into the required
-myna file format for the component. This may be part of execute.py, as well.
+1. `configure.py`: Module that configures the files within each Myna case folder
+generated during `myna config`. At the end of this stage, each case folder should be a
+valid case directory for whatever model is being run.
+2. `execute.py`: Module that executes the model for each case.
+3. `postprocess.py`: Module that converts the output of the model into the required
+myna file format for the component. This may be part of `execute.py`, as well.
 
-These scripts are run sequentially and are mainly separated for clarity of the app
-functionality and for handling runtime issues. *Technically* all functionality can
-be in one script, however, this may get confusing so it is recommended to split
-functions into three scripts. If the model is not Python-based, these scripts can
-simply wrap other scripts as needed. All steps are optional and if one of these
-scripts is not present, it will be ignored.
+These stage modules are imported and called sequentially by `Component.run_component`.
+Each module should define a function named for the stage (`configure`, `execute`, or
+`postprocess`) or a `main()` function. The stages are mainly separated for clarity of
+the app functionality and for handling runtime issues. *Technically* all functionality
+can be in one stage, however, this may get confusing so it is recommended to split
+functions into three stages. If the model is not Python-based, these stages can simply
+wrap other commands as needed. All steps are optional and if one of these modules is
+not present, it will be ignored.
 
 Many of the already implemented apps use the `argparse` library to parse
 user-specified inputs. In the input file, `configure`, `execute`, and
-`postprocess` allow users to pass options to each of the scripts
-for the app. Any parameters that you wish to have accessible to users are
-intended to be adjusted through such options, which are passed to the script via
-command line in the format `--key value` or `--key` for Boolean flags. For Boolean
-flags, the assumed behavior is False if the flag is not passed and True if the flag is
-passed.
+`postprocess` allow users to pass options to each stage for the app. Any parameters
+that you wish to have accessible to users are intended to be adjusted through such
+options, which are exposed to the active stage through `sys.argv` in the format
+`--key value` or `--key` for Boolean flags. For Boolean flags, the assumed behavior is
+False if the flag is not passed and True if the flag is passed.
+
+Applications that derive from `MynaApp` should read workflow state from app attributes
+such as `self.input_file`, `self.step_name`, `self.last_step_name`, and
+`self.step_index`. Avoid reading `MYNA_*` environment variables directly in new app
+code; those names remain only as a compatibility fallback for direct stage invocation.
 
 It is likely that your app will require a `template` directory, or a set of input
 files for your model that get copied into every case. If you are using a template
-directory, then the intended functionality is that during `config.py` the template
+directory, then the intended functionality is that during `configure.py` the template
 folder is copied into each of the case directory *and then updated*. Updating the files
 inside the original template folder should be avoided.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -72,8 +72,8 @@ The documentation harness is intentionally small:
 - `scripts/check_dev_tools.py` verifies that the current shell can run the repository's
   development toolchain.
 - `scripts/check_docs_harness.py` verifies required headings, relative links from
-  `.codex/AGENTS.md`, and architecture-doc updates when architecture-sensitive code
-  paths change.
+  `.codex/AGENTS.md`, required PR template guidance, PR template headings, and
+  architecture-doc updates when architecture-sensitive code paths change.
 
 Run the harness check with:
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -71,8 +71,9 @@ The documentation harness is intentionally small:
 - `docs/testing.md` and this page cover validation and maintenance details.
 - `scripts/check_dev_tools.py` verifies that the current shell can run the repository's
   development toolchain.
-- `scripts/check_docs_harness.py` verifies required headings and relative links from
-  `.codex/AGENTS.md`.
+- `scripts/check_docs_harness.py` verifies required headings, relative links from
+  `.codex/AGENTS.md`, and architecture-doc updates when architecture-sensitive code
+  paths change.
 
 Run the harness check with:
 

--- a/scripts/check_docs_harness.py
+++ b/scripts/check_docs_harness.py
@@ -7,6 +7,7 @@ CI, and minimal local development environments.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -45,6 +46,21 @@ REQUIRED_HEADINGS = {
         "## Handoff Checklist",
     ],
 }
+
+ARCHITECTURE_SENSITIVE_PATHS = [
+    "src/myna/core/workflow/",
+    "src/myna/core/components/",
+    "src/myna/core/app/",
+    "src/myna/core/context.py",
+    "src/myna/database/",
+    "src/myna/application/readme.md",
+]
+
+ARCHITECTURE_DOC_PATHS = [
+    "ARCHITECTURE.md",
+    "docs/developer_guide.md",
+    "docs/decisions/",
+]
 
 
 def fail(message: str) -> None:
@@ -104,9 +120,73 @@ def check_agents_links() -> None:
             fail(f".codex/AGENTS.md links to missing path: {raw_target}")
 
 
+def run_git_command(args: list[str]) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return []
+
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def get_changed_files() -> set[str]:
+    changed = set(run_git_command(["diff", "--name-only", "HEAD"]))
+    changed.update(
+        run_git_command(["ls-files", "--others", "--exclude-standard"])
+    )
+    return changed
+
+
+def path_matches_any(path: str, prefixes_or_paths: list[str]) -> bool:
+    return any(
+        path == candidate.rstrip("/") or path.startswith(candidate)
+        for candidate in prefixes_or_paths
+    )
+
+
+def check_architecture_docs_updated_for_sensitive_changes() -> None:
+    changed_files = get_changed_files()
+    if not changed_files:
+        return
+
+    sensitive_changes = sorted(
+        path
+        for path in changed_files
+        if path_matches_any(path, ARCHITECTURE_SENSITIVE_PATHS)
+    )
+    if not sensitive_changes:
+        return
+
+    docs_changes = sorted(
+        path
+        for path in changed_files
+        if path_matches_any(path, ARCHITECTURE_DOC_PATHS)
+    )
+    if docs_changes:
+        return
+
+    changed_list = "\n".join(f"  - {path}" for path in sensitive_changes)
+    required_list = "\n".join(f"  - {path}" for path in ARCHITECTURE_DOC_PATHS)
+    fail(
+        "architecture-sensitive files changed without architecture documentation "
+        "updates.\nChanged files:\n"
+        f"{changed_list}\nUpdate at least one of:\n{required_list}\n"
+        "If no docs update is needed, state that explicitly in the PR."
+    )
+
+
 def main() -> None:
     check_required_headings()
     check_agents_links()
+    check_architecture_docs_updated_for_sensitive_changes()
     print("docs harness check passed")
 
 

--- a/scripts/check_docs_harness.py
+++ b/scripts/check_docs_harness.py
@@ -62,6 +62,15 @@ ARCHITECTURE_DOC_PATHS = [
     "docs/decisions/",
 ]
 
+PR_TEMPLATE_REQUIRED_HEADINGS = [
+    "## Summary",
+    "## Related issues",
+    "## Details",
+    "## Impact",
+    "## Testing strategy",
+    "## Checklist",
+]
+
 
 def fail(message: str) -> None:
     print(f"docs harness check failed: {message}", file=sys.stderr)
@@ -118,6 +127,23 @@ def check_agents_links() -> None:
             fail(f".codex/AGENTS.md link escapes repository: {raw_target}")
         if not path.exists():
             fail(f".codex/AGENTS.md links to missing path: {raw_target}")
+
+
+def check_pr_template_guidance() -> None:
+    template_text = read_required_file(".github/pull_request_template.md")
+    for heading in PR_TEMPLATE_REQUIRED_HEADINGS:
+        if not has_heading(template_text, heading):
+            fail(f".github/pull_request_template.md is missing required heading: {heading}")
+
+    agents_text = read_required_file(".codex/AGENTS.md")
+    required_phrases = [
+        ".github/pull_request_template.md",
+        "Preserve the template headings and checklist",
+        "state behavior impact, risk, and testing strategy",
+    ]
+    for phrase in required_phrases:
+        if phrase not in agents_text:
+            fail(f".codex/AGENTS.md is missing PR template guidance: {phrase}")
 
 
 def run_git_command(args: list[str]) -> list[str]:
@@ -186,6 +212,7 @@ def check_architecture_docs_updated_for_sensitive_changes() -> None:
 def main() -> None:
     check_required_headings()
     check_agents_links()
+    check_pr_template_guidance()
     check_architecture_docs_updated_for_sensitive_changes()
     print("docs harness check passed")
 

--- a/scripts/check_docs_harness.py
+++ b/scripts/check_docs_harness.py
@@ -133,7 +133,9 @@ def check_pr_template_guidance() -> None:
     template_text = read_required_file(".github/pull_request_template.md")
     for heading in PR_TEMPLATE_REQUIRED_HEADINGS:
         if not has_heading(template_text, heading):
-            fail(f".github/pull_request_template.md is missing required heading: {heading}")
+            fail(
+                f".github/pull_request_template.md is missing required heading: {heading}"
+            )
 
     agents_text = read_required_file(".codex/AGENTS.md")
     required_phrases = [
@@ -165,9 +167,7 @@ def run_git_command(args: list[str]) -> list[str]:
 
 def get_changed_files() -> set[str]:
     changed = set(run_git_command(["diff", "--name-only", "HEAD"]))
-    changed.update(
-        run_git_command(["ls-files", "--others", "--exclude-standard"])
-    )
+    changed.update(run_git_command(["ls-files", "--others", "--exclude-standard"]))
     return changed
 
 
@@ -192,9 +192,7 @@ def check_architecture_docs_updated_for_sensitive_changes() -> None:
         return
 
     docs_changes = sorted(
-        path
-        for path in changed_files
-        if path_matches_any(path, ARCHITECTURE_DOC_PATHS)
+        path for path in changed_files if path_matches_any(path, ARCHITECTURE_DOC_PATHS)
     )
     if docs_changes:
         return

--- a/src/myna/application/additivefoam/solidification_region_reduced/app.py
+++ b/src/myna/application/additivefoam/solidification_region_reduced/app.py
@@ -495,10 +495,11 @@ class AdditiveFOAMRegionReduced(AdditiveFOAM):
 
         with working_directory(case_dict["case_dir"]):
             # Determine if parallel execution
+            step_index = self.step_index
+            if step_index is None:
+                step_index = self.step_number
             np = nested_get(
-                self.settings["steps"][int(os.environ["MYNA_STEP_INDEX"])][
-                    self.step_name
-                ],
+                self.settings["steps"][step_index][self.step_name],
                 ["execute", "np"],
                 default_value=1,
             )

--- a/src/myna/application/bnpy/bnpy.py
+++ b/src/myna/application/bnpy/bnpy.py
@@ -18,8 +18,10 @@ class Bnpy(MynaApp):
         self.app_type = "bnpy"
         self.sF = 0.5
         self.gamma = 8
-        self.settings = load_input(os.environ["MYNA_INPUT"])
-        self.input_dir = os.path.dirname(os.environ["MYNA_INPUT"])
+        if self.input_file is None:
+            raise ValueError("Bnpy apps require a Myna workflow input file.")
+        self.settings = load_input(self.input_file)
+        self.input_dir = os.path.dirname(self.input_file)
         self.resource_dir = os.path.join(self.input_dir, "myna_resources")
         self.resource_template_dir = os.path.join(
             self.resource_dir, *self.name.split("/")

--- a/src/myna/application/bnpy/cluster_solidification/execute.py
+++ b/src/myna/application/bnpy/cluster_solidification/execute.py
@@ -342,16 +342,16 @@ def main():
 
     # Parse command line arguments
     args = parser.parse_args()
-    settings = load_input(os.environ["MYNA_INPUT"])
+    settings = load_input(app.input_file)
     train_model = args.train_model
     overwrite = args.overwrite
 
     # Get expected Myna output files
-    step_name = os.environ["MYNA_STEP_NAME"]
+    step_name = app.step_name
     myna_files = settings["data"]["output_paths"][step_name]
     thermal_step_name = args.thermal
     if thermal_step_name is None:
-        thermal_step_name = os.environ["MYNA_LAST_STEP_NAME"]
+        thermal_step_name = app.last_step_name
     thermal_files = settings["data"]["output_paths"][thermal_step_name]
 
     # Assemble training data and train model

--- a/src/myna/application/bnpy/cluster_supervoxel/execute.py
+++ b/src/myna/application/bnpy/cluster_supervoxel/execute.py
@@ -389,11 +389,11 @@ def main():
     app.n_voxel_clusters = max(voxel_model.allocModel.K, 2)
 
     # Get expected Myna output files
-    step_name = os.environ["MYNA_STEP_NAME"]
+    step_name = app.step_name
     myna_files = app.settings["data"]["output_paths"][step_name]
     cluster_step_name = app.args.cluster
     if cluster_step_name == "":
-        cluster_step_name = os.environ["MYNA_LAST_STEP_NAME"]
+        cluster_step_name = app.last_step_name
     voxel_cluster_files = app.settings["data"]["output_paths"][cluster_step_name]
 
     # Assemble training data and train model

--- a/src/myna/application/readme.md
+++ b/src/myna/application/readme.md
@@ -8,29 +8,28 @@ functionality).
 
 `myna` expects a specific directory and file structure for each application (app):
 
-- Parent directories are named after the class names defined in
-[../src/myna/components/component_class_lookup.py].
-- Child directory names then correspond to an available app name
-for the parent class
-- Each available app can contain three stages of executables
-that will be called sequentially with the corresponding arguments from
-the myna_run input file:
+- Parent directories are named after available application names.
+- Child directory names correspond to the component class names defined in
+  `src/myna/core/components/component_class_lookup.py`.
+- Each available app can contain three Python stage modules that are imported and
+  called sequentially with the corresponding arguments from the `myna run` input file:
 
   1. configure.py <configure_args>
   2. execute.py <execute_args>
   3. postprocess.py <postprocess_args>
 
-- The expectation is that each configure, execute, and postprocess
-script will use the Python argparse module to parse command line inputs
-- If the model has a case template that it will copy from, then the
-convention is to name that directory "template" (this is
-not strictly necessary)
-- Other files can be included in the app directory for documentation or
-as resources, such as a readme file
+- Each stage module should define a function named for the stage (`configure`,
+  `execute`, or `postprocess`) or a `main()` function.
+- The expectation is that each configure, execute, and postprocess stage will use the
+  Python argparse module to parse command line inputs. `myna` temporarily populates
+  `sys.argv` for the active stage to preserve command-line parsing behavior.
+- Stage code should get workflow state from `MynaApp` attributes rather than directly
+  reading `MYNA_*` environment variables.
+- If the model has a case template that it will copy from, then the convention is to
+  name that directory "template" (this is not strictly necessary).
+- Other files can be included in the app directory for documentation or as resources,
+  such as a readme file.
 
-There is no technical difference between the three stages of executables
-on the backend of `myna`. The `os.system()` call is the same for each stage.
-The split into stages is more for organization of tasks into case setup,
-case execution, and tasks to be completed after a (successful) execution,
-which will be useful if implementing a more robust workflow manager in
-the future.
+There is no technical difference between the three stages on the backend of `myna`.
+The split into stages is for organization of tasks into case setup, case execution,
+and tasks to be completed after a successful execution.

--- a/src/myna/core/app/base.py
+++ b/src/myna/core/app/base.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import docker
 from docker.models.containers import Container
 from myna.core.app._argument_registrar import _ArgumentRegistrar
+from myna.core.context import current_workflow_context
 from myna.core.workflow.load_input import load_input
 from myna.core.utils import is_executable, get_quoted_str
 from myna.core.components import return_step_class
@@ -37,24 +38,44 @@ class MynaApp:
     ENV_APP_PATH = "MYNA_APP_PATH"
     ENV_STEP_NAME = "MYNA_STEP_NAME"
     ENV_LAST_STEP_NAME = "MYNA_LAST_STEP_NAME"
+    ENV_STEP_CLASS = "MYNA_STEP_CLASS"
+    ENV_STEP_INDEX = "MYNA_STEP_INDEX"
+    ENV_LAST_STEP_CLASS = "MYNA_LAST_STEP_CLASS"
 
     def __init__(self):
         # Set the print name as well as the Myna app and class names
         self.class_name: str | None = None
         self.app_type: str | None = None
+        self.step_class: str | None = None
+        self.last_step_class: str | None = None
 
-        # Get the names for the current and previous workflow step
-        self.step_name = os.environ.get(self.ENV_STEP_NAME)
-        self.last_step_name = os.environ.get(self.ENV_LAST_STEP_NAME)
+        # Get explicit workflow context first, falling back to legacy CLI environment
+        # variables for direct script invocation.
+        context = current_workflow_context()
+        if context is not None:
+            self.step_name = context.step_name
+            self.last_step_name = context.last_step_name
+            self.step_class = context.step_class
+            self.last_step_class = context.last_step_class
+            self.step_index = context.step_index
+            self.input_file = context.input_file
+        else:
+            self.step_name = os.environ.get(self.ENV_STEP_NAME)
+            self.last_step_name = os.environ.get(self.ENV_LAST_STEP_NAME)
+            self.step_class = os.environ.get(self.ENV_STEP_CLASS)
+            self.last_step_class = os.environ.get(self.ENV_LAST_STEP_CLASS)
+            self.input_file = os.environ.get(self.ENV_SETTINGS_FILE)
+            self.step_index = _parse_optional_int(os.environ.get(self.ENV_STEP_INDEX))
 
         # Get the input file contents and parse additional step information
-        self.input_file = os.environ.get(self.ENV_SETTINGS_FILE)
         self.settings = {}
         self.step_number = None
         if self.input_file is not None:
             self.settings = load_input(self.input_file)
             step_names = [list(x.keys())[0] for x in self.settings.get("steps", [])]
-            if self.step_name in step_names:
+            if self.step_index is not None:
+                self.step_number = self.step_index
+            elif self.step_name in step_names:
                 self.step_number = step_names.index(self.step_name)
 
         # Set up argparse
@@ -539,3 +560,9 @@ class MynaApp:
             open_resources = procs_in_use <= (self.args.maxproc - self.args.np)
             if not open_resources:
                 time.sleep(poll_interval)
+
+
+def _parse_optional_int(value):
+    if value is None:
+        return None
+    return int(value)

--- a/src/myna/core/components/component.py
+++ b/src/myna/core/components/component.py
@@ -65,11 +65,14 @@ class Component:
                 if all(valid):
                     print(f"All output files are valid for step {self.name}.")
                 else:
-                    print(
-                        f"WARNING: Only found {sum(valid)} valid output files out of {len(output_files)}"
-                        + f" output files for step {self.name}. Expected output files:"
+                    message = (
+                        f"Only found {sum(valid)} valid output files out of "
+                        f"{len(output_files)} output files for step {self.name}. "
+                        "Expected output files:"
                     )
+                    print(f"ERROR: {message}")
                     [print("\t" + x) for x in output_files]
+                    raise RuntimeError(message)
             else:
                 print(
                     f"No execute command was specified for step {self.name}. The expected output files are:"

--- a/src/myna/core/components/component.py
+++ b/src/myna/core/components/component.py
@@ -8,13 +8,16 @@
 #
 """Base class for workflow components"""
 
+import importlib
+import importlib.util
 import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal
-import subprocess
 import myna
 import myna.database
+from myna.core.context import get_workflow_input_file, workflow_context
 from myna.core.workflow import load_input
 from myna.core.utils import nested_get, get_quoted_str
 import warnings
@@ -43,57 +46,17 @@ class Component:
         self.data = {}
         self.types = ["build"]
         self.workspace = None
+        self.input_file = None
+        self.step_index = None
+        self.last_step_name = None
+        self.last_step_class = None
 
     def run_component(self):
-        """Runs the configure.py, execute.py, and postprocess.py
-        for selected component class & application combination"""
+        """Run configure, execute, and postprocess stages for this component."""
 
-        # Run component configure.py script
-        configure_path = os.path.join(
-            os.environ["MYNA_APP_PATH"],
-            self.component_application,
-            self.component_class,
-            "configure.py",
-        )
-        if os.path.exists(configure_path):
-            cmd = [sys.executable, configure_path]
-            cmd.extend(self.get_step_args_list("configure"))
-            cmd = self.cmd_preformat(cmd)
-            print(f"myna run: {cmd=}")
-            with subprocess.Popen(cmd) as p:
-                p.wait()
-
-        # Run component execute.py script
-        has_executed = False
-        execute_path = os.path.join(
-            os.environ["MYNA_APP_PATH"],
-            self.component_application,
-            self.component_class,
-            "execute.py",
-        )
-        if os.path.exists(execute_path):
-            cmd = [sys.executable, execute_path]
-            cmd.extend(self.get_step_args_list("execute"))
-            cmd = self.cmd_preformat(cmd)
-            print(f"myna run: {cmd=}")
-            with subprocess.Popen(cmd) as p:
-                p.wait()
-            has_executed = True
-
-        # Run component postprocess.py script
-        postprocess_path = os.path.join(
-            os.environ["MYNA_APP_PATH"],
-            self.component_application,
-            self.component_class,
-            "postprocess.py",
-        )
-        if os.path.exists(postprocess_path):
-            cmd = [sys.executable, postprocess_path]
-            cmd.extend(self.get_step_args_list("postprocess"))
-            cmd = self.cmd_preformat(cmd)
-            print(f"myna run: {cmd=}")
-            with subprocess.Popen(cmd) as p:
-                p.wait()
+        self._run_stage("configure")
+        has_executed = self._run_stage("execute")
+        self._run_stage("postprocess")
 
         # Check output of component
         output_files, _, valid = self.get_output_files()
@@ -112,6 +75,67 @@ class Component:
                     f"No execute command was specified for step {self.name}. The expected output files are:"
                 )
                 [print("\t" + x) for x in output_files]
+
+    def _run_stage(self, operation: Literal["configure", "execute", "postprocess"]):
+        """Import and run an application stage module in the current process."""
+
+        module_name = ".".join(
+            [
+                "myna",
+                "application",
+                self.component_application,
+                self.component_class,
+                operation,
+            ]
+        )
+        try:
+            spec = importlib.util.find_spec(module_name)
+        except ModuleNotFoundError:
+            spec = None
+        if spec is None:
+            return False
+
+        module = importlib.import_module(module_name)
+        stage_func = getattr(module, operation, None)
+        if stage_func is None:
+            stage_func = getattr(module, "main", None)
+        if stage_func is None:
+            raise AttributeError(
+                f"Application stage module '{module_name}' does not define "
+                f"'{operation}()' or 'main()'."
+            )
+
+        stage_args = self.cmd_preformat(self.get_step_args_list(operation))
+        script_name = spec.origin or module_name
+        cmd = [sys.executable, script_name]
+        cmd.extend(stage_args)
+        print(f"myna run: {cmd=}")
+
+        with workflow_context(
+            input_file=self.input_file,
+            step_name=self.name,
+            step_class=self.component_class,
+            step_index=self.step_index,
+            last_step_name=self.last_step_name,
+            last_step_class=self.last_step_class,
+        ):
+            with self._stage_argv(script_name, stage_args):
+                try:
+                    stage_func()
+                except SystemExit as exc:
+                    if exc.code not in (None, 0):
+                        raise
+        return True
+
+    @contextmanager
+    def _stage_argv(self, script_name, args):
+        previous_argv = sys.argv
+        sys.argv = [script_name]
+        sys.argv.extend(args)
+        try:
+            yield
+        finally:
+            sys.argv = previous_argv
 
     def cmd_preformat(self, raw_cmd):
         """Replace placeholder names in command arguments and adds executable argument
@@ -202,7 +226,11 @@ class Component:
         files = []
 
         # Get build name
-        input_dir = os.path.abspath(os.path.dirname(os.environ["MYNA_INPUT"]))
+        input_file = self.input_file or get_workflow_input_file()
+        if input_file is None:
+            input_dir = os.getcwd()
+        else:
+            input_dir = os.path.abspath(os.path.dirname(input_file))
         build = nested_get(self.data, ["build", "name"], "myna_output")
         filled_template = template.replace("{{build}}", build)
 
@@ -460,9 +488,13 @@ class Component:
             print(f"- step {self.name}: No valid output files found.")
         else:
             # Use the database sync functionality
-            synced_files = datatype.sync(
-                self.component_application, self.types, self.output_requirement, files
-            )
+            with workflow_context(input_file=self.input_file, step_name=self.name):
+                synced_files = datatype.sync(
+                    self.component_application,
+                    self.types,
+                    self.output_requirement,
+                    files,
+                )
 
         return synced_files
 

--- a/src/myna/core/context.py
+++ b/src/myna/core/context.py
@@ -1,0 +1,100 @@
+#
+# Copyright (c) Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+"""Workflow context shared between Myna workflow orchestration and apps."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+import os
+
+
+@dataclass(frozen=True)
+class WorkflowContext:
+    """Explicit workflow state for an active Myna operation."""
+
+    input_file: str | None = None
+    step_name: str | None = None
+    step_class: str | None = None
+    step_index: int | None = None
+    last_step_name: str | None = None
+    last_step_class: str | None = None
+
+
+_CURRENT_WORKFLOW_CONTEXT: ContextVar[WorkflowContext | None] = ContextVar(
+    "myna_current_workflow_context", default=None
+)
+
+
+def current_workflow_context() -> WorkflowContext | None:
+    """Return the active workflow context, if one has been set."""
+
+    return _CURRENT_WORKFLOW_CONTEXT.get()
+
+
+@contextmanager
+def workflow_context(
+    *,
+    input_file: str | None = None,
+    step_name: str | None = None,
+    step_class: str | None = None,
+    step_index: int | None = None,
+    last_step_name: str | None = None,
+    last_step_class: str | None = None,
+):
+    """Temporarily set explicit workflow state for in-process app execution."""
+
+    parent = current_workflow_context()
+    context = WorkflowContext(
+        input_file=(
+            input_file
+            if input_file is not None
+            else _parent_value(parent, "input_file")
+        ),
+        step_name=(
+            step_name if step_name is not None else _parent_value(parent, "step_name")
+        ),
+        step_class=(
+            step_class
+            if step_class is not None
+            else _parent_value(parent, "step_class")
+        ),
+        step_index=(
+            step_index
+            if step_index is not None
+            else _parent_value(parent, "step_index")
+        ),
+        last_step_name=last_step_name
+        if last_step_name is not None
+        else _parent_value(parent, "last_step_name"),
+        last_step_class=last_step_class
+        if last_step_class is not None
+        else _parent_value(parent, "last_step_class"),
+    )
+    token = _CURRENT_WORKFLOW_CONTEXT.set(context)
+    try:
+        yield context
+    finally:
+        _CURRENT_WORKFLOW_CONTEXT.reset(token)
+
+
+def get_workflow_input_file(default: str | None = None) -> str | None:
+    """Return the active workflow input file, falling back to legacy env state."""
+
+    context = current_workflow_context()
+    if context is not None and context.input_file is not None:
+        return context.input_file
+    return os.environ.get("MYNA_INPUT", default)
+
+
+def _parent_value(parent: WorkflowContext | None, field: str):
+    if parent is None:
+        return None
+    return getattr(parent, field)

--- a/src/myna/core/db/database.py
+++ b/src/myna/core/db/database.py
@@ -11,6 +11,7 @@
 import os
 from datetime import datetime
 import yaml
+from myna.core.context import get_workflow_input_file
 from myna.core.workflow import load_input
 from myna.core.utils import strf_datetime
 
@@ -55,7 +56,10 @@ class Database:
             simulation_file_path (str): Path to the simulation file being synced
             segment_key (str): Key identifying the segment in the database"""
         step_name = os.path.basename(os.path.dirname(simulation_file_path))
-        step_list = load_input(os.environ["MYNA_INPUT"])["steps"]
+        input_file = get_workflow_input_file()
+        if input_file is None:
+            raise ValueError("Cannot write sync metadata without a Myna input file.")
+        step_list = load_input(input_file)["steps"]
         step_dict = step_list[
             [list(step.keys())[0] for step in step_list].index(step_name)
         ]

--- a/src/myna/core/metadata/file.py
+++ b/src/myna/core/metadata/file.py
@@ -10,6 +10,7 @@
 
 import shutil
 import os
+from myna.core.context import get_workflow_input_file
 
 
 class BuildFile:
@@ -42,9 +43,11 @@ class BuildFile:
     def set_local_resource_dir(self):
         """Get the local resource directory and make if it doesn't exist"""
 
-        input_dir = os.path.abspath(os.path.dirname(os.environ["MYNA_INPUT"]))
-        if input_dir is None:
+        input_file = get_workflow_input_file()
+        if input_file is None:
             input_dir = "."
+        else:
+            input_dir = os.path.abspath(os.path.dirname(input_file))
         resource_dir = os.path.abspath(os.path.join(input_dir, "myna_resources"))
         os.makedirs(resource_dir, exist_ok=True)
         self.resource_dir = resource_dir

--- a/src/myna/core/workflow/__init__.py
+++ b/src/myna/core/workflow/__init__.py
@@ -49,6 +49,12 @@ from .load_input import (
     load_input,
     write_input,
 )
+from myna.core.context import (
+    WorkflowContext,
+    current_workflow_context,
+    get_workflow_input_file,
+    workflow_context,
+)
 from .status import format_class_string_to_list, write_codebase_status_to_file
 
 __all__ = [
@@ -60,6 +66,10 @@ __all__ = [
     "get_validated_input_filetype",
     "load_input",
     "write_input",
+    "WorkflowContext",
+    "current_workflow_context",
+    "get_workflow_input_file",
+    "workflow_context",
     "format_class_string_to_list",
     "write_codebase_status_to_file",
 ]

--- a/src/myna/core/workflow/run.py
+++ b/src/myna/core/workflow/run.py
@@ -45,17 +45,14 @@ def run(input_file, step=None):
         step: name of step to run, runs all if None"""
 
     steps_to_run = myna.core.utils.str_to_list(step)
-
-    # Set environmental variable for input file location
-    os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
-    os.environ["MYNA_RUN_INPUT"] = os.path.abspath(
-        input_file
-    )  # MYNA_RUN_INPUT will be deprecated in future versions
+    input_file = os.path.abspath(input_file)
 
     # Load the initial input file to get the steps
     initial_settings = load_input(input_file)
 
     # Run through each step
+    last_step_name = ""
+    last_step_class = ""
     for index, step in enumerate(initial_settings["steps"]):
         # Load the input file at each step in case one the previous step has updated the inputs
         settings = load_input(input_file)
@@ -67,17 +64,10 @@ def run(input_file, step=None):
         step_obj.name = step_name
         step_obj.component_class = component_class_name
         step_obj.component_application = step[step_name]["application"]
-
-        # Set environmental variable for the step name
-        if index != 0:
-            os.environ["MYNA_LAST_STEP_NAME"] = os.environ["MYNA_STEP_NAME"]
-            os.environ["MYNA_LAST_STEP_CLASS"] = os.environ["MYNA_STEP_CLASS"]
-        else:
-            os.environ["MYNA_LAST_STEP_NAME"] = ""
-            os.environ["MYNA_LAST_STEP_CLASS"] = ""
-        os.environ["MYNA_STEP_NAME"] = step_name
-        os.environ["MYNA_STEP_CLASS"] = component_class_name
-        os.environ["MYNA_STEP_INDEX"] = str(index)
+        step_obj.input_file = input_file
+        step_obj.step_index = index
+        step_obj.last_step_name = last_step_name
+        step_obj.last_step_class = last_step_class
 
         # Apply the settings and execute the component, as needed
         run_step = True
@@ -93,3 +83,6 @@ def run(input_file, step=None):
                 step[step_name], settings.get("data"), settings.get("myna")
             )
             step_obj.run_component()
+
+        last_step_name = step_name
+        last_step_class = component_class_name

--- a/src/myna/core/workflow/sync.py
+++ b/src/myna/core/workflow/sync.py
@@ -46,17 +46,14 @@ def sync(input_file, step=None):
         step: name of step to sync, syncs all if None"""
 
     steps_to_sync = myna.core.utils.str_to_list(step)
-
-    # Set environmental variable for input file location
-    os.environ["MYNA_INPUT"] = os.path.abspath(input_file)
-    os.environ["MYNA_SYNC_INPUT"] = os.path.abspath(
-        input_file
-    )  # MYNA_SYNC_INPUT will be deprecated in future versions
+    input_file = os.path.abspath(input_file)
 
     # Load the initial input file to get the steps
     initial_settings = load_input(input_file)
 
     # Run through each step
+    last_step_name = ""
+    last_step_class = ""
     for index, step in enumerate(initial_settings["steps"]):
         # Load the input file at each step in case one the previous step has updated the inputs
         settings = load_input(input_file)
@@ -69,17 +66,10 @@ def sync(input_file, step=None):
         step_obj.name = step_name
         step_obj.component_class = component_class_name
         step_obj.component_application = component_app_name
-
-        # Set environmental variable for the step name
-        if index != 0:
-            os.environ["MYNA_LAST_STEP_NAME"] = os.environ["MYNA_STEP_NAME"]
-            os.environ["MYNA_LAST_STEP_CLASS"] = os.environ["MYNA_STEP_CLASS"]
-        else:
-            os.environ["MYNA_LAST_STEP_NAME"] = ""
-            os.environ["MYNA_LAST_STEP_CLASS"] = ""
-        os.environ["MYNA_STEP_NAME"] = step_name
-        os.environ["MYNA_STEP_CLASS"] = component_class_name
-        os.environ["MYNA_STEP_INDEX"] = str(index)
+        step_obj.input_file = input_file
+        step_obj.step_index = index
+        step_obj.last_step_name = last_step_name
+        step_obj.last_step_class = last_step_class
 
         # Apply the settings and execute the component, as needed
         sync_step = True
@@ -93,3 +83,6 @@ def sync(input_file, step=None):
         if sync_step:
             step_obj.apply_settings(step[step_name], settings["data"], settings["myna"])
             step_obj.sync_output_files()
+
+        last_step_name = step_name
+        last_step_class = component_class_name

--- a/src/myna/database/nist_ambench_2022.py
+++ b/src/myna/database/nist_ambench_2022.py
@@ -11,6 +11,7 @@
 from myna.core.db import Database
 from myna.core import metadata
 from myna.core.utils import downsample_to_image, nested_get
+from myna.core.context import get_workflow_input_file
 from myna.core.workflow import load_input
 import matplotlib.pyplot as plt
 import numpy as np
@@ -302,7 +303,10 @@ class AMBench2022(Database):
             component_name = os.path.basename(os.path.dirname(files[0]))
             unique_regions = sorted(set(regions))
             unique_parts = sorted(set(parts))
-            settings = load_input(os.environ["MYNA_INPUT"])
+            input_file = get_workflow_input_file()
+            if input_file is None:
+                raise ValueError("Region sync requires a Myna input file.")
+            settings = load_input(input_file)
             for region in unique_regions:
                 for part in unique_parts:
                     part_dict = nested_get(settings, ["data", "build", "parts"]).get(

--- a/src/myna/database/pelican.py
+++ b/src/myna/database/pelican.py
@@ -18,6 +18,7 @@ import polars as pl
 from polars.datatypes import Float64
 from myna.core import metadata
 from myna.core.db import Database
+from myna.core.context import get_workflow_input_file
 from myna.core.utils import nested_get, nested_set
 
 
@@ -104,7 +105,9 @@ class Pelican(Database):
             layer: (str) "layer" corresponding to the time_segment for the part in
                 the Myna input file
         """
-        input_file = os.environ["MYNA_INPUT"]
+        input_file = get_workflow_input_file()
+        if input_file is None:
+            raise ValueError("Pelican segment details require a Myna input file.")
         with open(input_file, "r", encoding="utf-8") as f:
             input_dict = yaml.safe_load(f)
         segment = nested_get(

--- a/src/myna/database/peregrine.py
+++ b/src/myna/database/peregrine.py
@@ -11,6 +11,7 @@
 from myna.core.db import Database
 from myna.core import metadata
 from myna.core.utils import downsample_to_image, get_synonymous_key, nested_get
+from myna.core.context import get_workflow_input_file
 from myna.core.workflow import load_input
 import matplotlib.pyplot as plt
 import os
@@ -261,7 +262,10 @@ class PeregrineDB(Database):
             component_name = os.path.basename(os.path.dirname(files[0]))
             unique_regions = sorted(set(regions))
             unique_parts = sorted(set(parts))
-            settings = load_input(os.environ["MYNA_INPUT"])
+            input_file = get_workflow_input_file()
+            if input_file is None:
+                raise ValueError("Region sync requires a Myna input file.")
+            settings = load_input(input_file)
             for region in unique_regions:
                 for part in unique_parts:
                     part_dict = nested_get(settings, ["data", "build", "parts"]).get(

--- a/tests/test_workflow_context.py
+++ b/tests/test_workflow_context.py
@@ -1,0 +1,187 @@
+#
+# Copyright (c) Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+import importlib
+from importlib.machinery import ModuleSpec
+import os
+import sys
+import types
+
+from myna.core.app.base import MynaApp
+from myna.core.components.component import Component
+import myna.core.components
+from myna.core.context import current_workflow_context, workflow_context
+from myna.core.workflow.run import run
+
+
+WORKFLOW_ENV_KEYS = [
+    "MYNA_INPUT",
+    "MYNA_RUN_INPUT",
+    "MYNA_SYNC_INPUT",
+    "MYNA_STEP_NAME",
+    "MYNA_STEP_CLASS",
+    "MYNA_STEP_INDEX",
+    "MYNA_LAST_STEP_NAME",
+    "MYNA_LAST_STEP_CLASS",
+]
+
+
+def _clear_workflow_env(monkeypatch):
+    for key in WORKFLOW_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_myna_app_reads_explicit_workflow_context(monkeypatch, tmp_path):
+    _clear_workflow_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["test"])
+    input_file = tmp_path / "input.yaml"
+    input_file.write_text(
+        """
+steps:
+- demo:
+    class: demo_class
+    application: demo_app
+data: {}
+myna: {}
+""",
+        encoding="utf-8",
+    )
+
+    with workflow_context(
+        input_file=os.fspath(input_file),
+        step_name="demo",
+        step_class="demo_class",
+        step_index=0,
+        last_step_name="previous",
+    ):
+        app = MynaApp()
+
+    assert app.input_file == os.fspath(input_file)
+    assert app.step_name == "demo"
+    assert app.step_class == "demo_class"
+    assert app.step_number == 0
+    assert app.last_step_name == "previous"
+
+
+def test_component_runs_stage_with_context_without_env(monkeypatch, tmp_path):
+    _clear_workflow_env(monkeypatch)
+    input_file = tmp_path / "input.yaml"
+    input_file.write_text(
+        "steps: []\ndata:\n  build:\n    name: build\nmyna: {}\n",
+        encoding="utf-8",
+    )
+    module_name = "myna.application.fakeapp.fakeclass.configure"
+    captured = {}
+    original_import_module = importlib.import_module
+
+    def configure():
+        context = current_workflow_context()
+        captured["context"] = context
+        captured["argv"] = list(sys.argv)
+        captured["env_step"] = os.environ.get("MYNA_STEP_NAME")
+
+    fake_module = types.SimpleNamespace(configure=configure)
+
+    def fake_find_spec(name):
+        if name == module_name:
+            return ModuleSpec(name, loader=None, origin="/tmp/configure.py")
+        return None
+
+    def fake_import_module(name):
+        if name == module_name:
+            return fake_module
+        return original_import_module(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    component = Component()
+    component.name = "demo"
+    component.component_application = "fakeapp"
+    component.component_class = "fakeclass"
+    component.input_file = os.fspath(input_file)
+    component.step_index = 1
+    component.last_step_name = "previous"
+    component.configure_dict = {"example": "value"}
+    component.data = {"build": {"name": "build"}}
+
+    previous_argv = list(sys.argv)
+    component.run_component()
+
+    assert captured["context"].input_file == os.fspath(input_file)
+    assert captured["context"].step_name == "demo"
+    assert captured["context"].step_class == "fakeclass"
+    assert captured["context"].step_index == 1
+    assert captured["context"].last_step_name == "previous"
+    assert captured["argv"] == ["/tmp/configure.py", "--example", "value"]
+    assert captured["env_step"] is None
+    assert sys.argv == previous_argv
+
+
+def test_run_passes_workflow_context_without_setting_env(monkeypatch, tmp_path):
+    _clear_workflow_env(monkeypatch)
+    input_file = tmp_path / "input.yaml"
+    input_file.write_text(
+        """
+steps:
+- first:
+    class: first_class
+    application: fake
+- second:
+    class: second_class
+    application: fake
+data:
+  build:
+    name: build
+myna: {}
+""",
+        encoding="utf-8",
+    )
+    calls = []
+
+    class DummyComponent(Component):
+        def run_component(self):
+            calls.append(
+                {
+                    "name": self.name,
+                    "class": self.component_class,
+                    "input_file": self.input_file,
+                    "step_index": self.step_index,
+                    "last_step_name": self.last_step_name,
+                    "env_step": os.environ.get("MYNA_STEP_NAME"),
+                }
+            )
+
+    monkeypatch.setattr(
+        myna.core.components,
+        "return_step_class",
+        lambda component_class_name: DummyComponent(),
+    )
+
+    run(os.fspath(input_file))
+
+    assert calls == [
+        {
+            "name": "first",
+            "class": "first_class",
+            "input_file": os.path.abspath(input_file),
+            "step_index": 0,
+            "last_step_name": "",
+            "env_step": None,
+        },
+        {
+            "name": "second",
+            "class": "second_class",
+            "input_file": os.path.abspath(input_file),
+            "step_index": 1,
+            "last_step_name": "first",
+            "env_step": None,
+        },
+    ]
+    for key in WORKFLOW_ENV_KEYS:
+        assert key not in os.environ

--- a/tests/test_workflow_context.py
+++ b/tests/test_workflow_context.py
@@ -12,10 +12,13 @@ import os
 import sys
 import types
 
+import pytest
+
 from myna.core.app.base import MynaApp
 from myna.core.components.component import Component
 import myna.core.components
 from myna.core.context import current_workflow_context, workflow_context
+from myna.core.files.file import File
 from myna.core.workflow.run import run
 
 
@@ -185,3 +188,60 @@ myna: {}
     ]
     for key in WORKFLOW_ENV_KEYS:
         assert key not in os.environ
+
+
+class MissingOutputFile(File):
+    """Output file type used to exercise run-time validation."""
+
+    def __init__(self, file):
+        super().__init__(file)
+        self.filetype = ".csv"
+
+    def file_is_valid(self):
+        return True
+
+
+def test_component_run_raises_when_execute_does_not_produce_output(
+    monkeypatch, tmp_path
+):
+    _clear_workflow_env(monkeypatch)
+    input_file = tmp_path / "input.yaml"
+    input_file.write_text(
+        "steps: []\ndata:\n  build:\n    name: build\nmyna: {}\n",
+        encoding="utf-8",
+    )
+    module_name = "myna.application.fakeapp.fakeclass.execute"
+    original_import_module = importlib.import_module
+
+    def execute():
+        return None
+
+    fake_module = types.SimpleNamespace(execute=execute)
+
+    def fake_find_spec(name):
+        if name == module_name:
+            return ModuleSpec(name, loader=None, origin="/tmp/execute.py")
+        return None
+
+    def fake_import_module(name):
+        if name == module_name:
+            return fake_module
+        return original_import_module(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    component = Component()
+    component.name = "demo"
+    component.component_application = "fakeapp"
+    component.component_class = "fakeclass"
+    component.input_file = os.fspath(input_file)
+    component.data = {"build": {"name": "build"}}
+    component.output_requirement = MissingOutputFile
+    component.output_template = "result.csv"
+
+    with pytest.raises(
+        RuntimeError,
+        match="Only found 0 valid output files out of 1 output files for step demo",
+    ):
+        component.run_component()


### PR DESCRIPTION
## Summary

Make workflow runs fail when an executed step does not produce all expected valid outputs.

## Related issues

- Closes #139

## Details

This fixes a bug where example tests could pass even when a workflow case failed to complete. `Component.run_component()` previously printed a warning if an execute stage finished but the expected output files were missing or invalid. Because no exception was raised, pytest and CI could still report success.

The fix changes that post-run validation path to raise a `RuntimeError` after listing the expected output files. A regression test covers an execute stage that returns successfully but leaves its declared output missing.

## Impact

Risk level: Low.

This changes failure behavior for workflows with declared output requirements: missing or invalid outputs after execution now fail loudly instead of logging a warning. That should make example tests and CI catch incomplete runs reliably.

## Testing strategy

Environment:
- Local repo `.venv`
- Python 3.12.10
- pytest 9.0.2

Commands run:
- `.venv/bin/python -m pytest tests/test_workflow_context.py`
- `.venv/bin/python -m pytest tests/test_workflow_context.py tests/test_component_output_paths.py`
- `.venv/bin/python -m pytest`
- `git diff --check`

Note: `uv` was not available in this shell, so testing used the repo `.venv`. External example CI jobs were not run locally because they require the external application/container environment.

## Checklist

- [x] Architecture/docs impact considered. Updated `ARCHITECTURE.md`, developer docs,
      and/or ADRs where needed.