### PR TITLE
feat/cubit: add controls for microstructure meshing

### DIFF
--- a/examples/cases/vtk_to_exodus_region/input.yaml
+++ b/examples/cases/vtk_to_exodus_region/input.yaml
@@ -14,7 +14,7 @@ steps:
       refine-region: 1
     execute:
       batch: True
-      np: 2
+      np: 16
       mpiexec: mpirun
       mpiflags: --bind-to none
 - exaca:
@@ -24,11 +24,12 @@ steps:
     configure:
       cell-size: 2.5
       sub-size: 12.3
-      nd: 250
-      mu: 21
-      std: 3
+      nd: 246
+      mu: 17.2
+      std: 1
     execute:
       batch: True
+      np: 32
 - convert_mesh:
     class: vtk_to_exodus_region
     application: cubit
@@ -36,7 +37,8 @@ steps:
       cubitpath: /home/cloud/Cubit-17.02
       downsample: 4
       mpiexec: /home/cloud/Cubit-17.02/bin/mpiexec
-      np: 2
+      np: 16
+      orientation-segment-gb: 2
 - deer:
     class: creep_timeseries_region
     application: deer
@@ -57,6 +59,6 @@ data:
       P5:
         regions:
           r1:
-            layers: [51]
+            layers: [51, 52]
             x: 0.2
             y: 0.021

--- a/src/myna/application/cubit/vtk_to_exodus_region/app.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/app.py
@@ -11,6 +11,7 @@
 import os
 import glob
 import copy
+import math
 import shutil
 import json
 import subprocess
@@ -65,6 +66,14 @@ class CubitVtkToExodusApp(CubitApp):
             type=str,
             help="(str) name of input file in ExaCA Myna workflow step template"
             + "generated the VTK file",
+        )
+        self.register_argument(
+            "--orientation-segment-gb",
+            default=None,
+            type=float,
+            help="Optional target size in GB per orientation-mapping subregion. "
+            + "If provided, Euler angle data are mapped and written in serial "
+            + "segments sized from the generated Exodus filesize.",
         )
         super().parse_execute_arguments()
 
@@ -182,13 +191,11 @@ class CubitVtkToExodusApp(CubitApp):
 
                 # Append grain ID array and Euler angles to Exodus file
                 with Dataset(exodus_prefix + ".e", "r+") as exodus_object:
-                    # Get ID array data to write
                     elem_block_ids = exodus_object.variables["eb_prop1"][:]
                     elem_orig_ids = np.array(
                         [new_id_dict[key] for key in elem_block_ids]
                     )
 
-                    # Get Euler angle data to write
                     # > [! note]
                     # > This is the section of the application that makes
                     # > the application ExaCA-specific. Another method of passing
@@ -201,26 +208,78 @@ class CubitVtkToExodusApp(CubitApp):
                         exaca_inputs = json.load(f)
                     ref_id_file = exaca_inputs["GrainOrientationFile"]
                     df_ref_ids = load_grain_ids(ref_id_file)
-                    elem_ref_ids = grain_id_to_reference_id(
-                        elem_orig_ids, len(df_ref_ids)
+                    self.write_exodus_block_data(
+                        exodus_object,
+                        elem_orig_ids,
+                        df_ref_ids,
+                        os.path.join(case_directory, exodus_prefix + ".e"),
                     )
-                    df_elems = df_ref_ids.loc[elem_ref_ids]
 
-                    # Create new variables in Exodus file
-                    block_data_dict = {
-                        "id_array": elem_orig_ids,
-                        "euler_bunge_zxz_phi1": df_elems["phi1"].to_numpy(),
-                        "euler_bunge_zxz_Phi": df_elems["Phi"].to_numpy(),
-                        "euler_bunge_zxz_phi2": df_elems["phi2"].to_numpy(),
-                    }
-                    for block_data_name, block_data_value in block_data_dict.items():
-                        if block_data_name not in exodus_object.variables:
-                            block_data = exodus_object.createVariable(
-                                block_data_name, block_data_value.dtype, ("num_el_blk",)
-                            )
+    def get_orientation_chunk_size(self, exodus_file, num_blocks):
+        """Get the number of blocks to map per serial orientation segment."""
 
-                            # Write data to the new variable
-                            block_data[:] = block_data_value
+        segment_size_gb = self.args.orientation_segment_gb
+        if segment_size_gb is None:
+            return None
+        if segment_size_gb <= 0:
+            raise ValueError("--orientation-segment-gb must be greater than zero")
+        if num_blocks <= 0:
+            return None
+
+        file_size_gb = os.path.getsize(exodus_file) / (1024.0**3)
+        num_segments = max(1, math.ceil(file_size_gb / segment_size_gb))
+        return max(1, math.ceil(num_blocks / num_segments))
+
+    @staticmethod
+    def ensure_exodus_variable(exodus_object, variable_name, dtype):
+        """Ensure an Exodus variable exists and return it."""
+
+        if variable_name not in exodus_object.variables:
+            return exodus_object.createVariable(variable_name, dtype, ("num_el_blk",))
+        return exodus_object.variables[variable_name]
+
+    def write_exodus_block_data(
+        self, exodus_object, elem_orig_ids, df_ref_ids, exodus_file
+    ):
+        """Write original grain ids and Euler-angle block data to the Exodus file."""
+
+        phi1_ref = df_ref_ids["phi1"].to_numpy()
+        Phi_ref = df_ref_ids["Phi"].to_numpy()
+        phi2_ref = df_ref_ids["phi2"].to_numpy()
+        num_blocks = len(elem_orig_ids)
+        chunk_size = self.get_orientation_chunk_size(exodus_file, num_blocks)
+
+        id_array = self.ensure_exodus_variable(
+            exodus_object, "id_array", elem_orig_ids.dtype
+        )
+        phi1_array = self.ensure_exodus_variable(
+            exodus_object, "euler_bunge_zxz_phi1", phi1_ref.dtype
+        )
+        Phi_array = self.ensure_exodus_variable(
+            exodus_object, "euler_bunge_zxz_Phi", Phi_ref.dtype
+        )
+        phi2_array = self.ensure_exodus_variable(
+            exodus_object, "euler_bunge_zxz_phi2", phi2_ref.dtype
+        )
+
+        if chunk_size is None:
+            elem_ref_ids = grain_id_to_reference_id(elem_orig_ids, len(df_ref_ids))
+            id_array[:] = elem_orig_ids
+            phi1_array[:] = phi1_ref[elem_ref_ids]
+            Phi_array[:] = Phi_ref[elem_ref_ids]
+            phi2_array[:] = phi2_ref[elem_ref_ids]
+            return
+
+        for start in range(0, num_blocks, chunk_size):
+            stop = min(num_blocks, start + chunk_size)
+            elem_orig_ids_chunk = elem_orig_ids[start:stop]
+            elem_ref_ids_chunk = grain_id_to_reference_id(
+                elem_orig_ids_chunk, len(df_ref_ids)
+            )
+            id_array[start:stop] = elem_orig_ids_chunk
+            phi1_array[start:stop] = phi1_ref[elem_ref_ids_chunk]
+            Phi_array[start:stop] = Phi_ref[elem_ref_ids_chunk]
+            phi2_array[start:stop] = phi2_ref[elem_ref_ids_chunk]
 
     def mesh_all_cases(self):
         """Generate Exodus mesh files for all cases in the Myna workflow step"""

--- a/src/myna/application/cubit/vtk_to_exodus_region/app.py
+++ b/src/myna/application/cubit/vtk_to_exodus_region/app.py
@@ -14,11 +14,16 @@ import copy
 import math
 import shutil
 import json
+import shlex
 import subprocess
+from pathlib import Path
 import numpy as np
 from vtk import (  # pylint: disable=no-name-in-module
+    vtkImageConnectivityFilter,
     vtkStructuredPointsReader,
     vtkExtractVOI,
+    vtkXMLImageDataReader,
+    vtkXMLImageDataWriter,
 )
 from vtkmodules.util.numpy_support import vtk_to_numpy
 from myna.application.cubit import CubitApp
@@ -35,6 +40,16 @@ class CubitVtkToExodusApp(CubitApp):
         self.class_name = "vtk_to_exodus"
 
     def parse_execute_arguments(self):
+        self.register_argument(
+            "--spn-xyz-order",
+            default=5,
+            choices=range(6),
+            type=int,
+            help="Ordering of cells in the SPN file passed to Sculpt "
+            + "(0=xyz, 1=xzy, 2=yxz, 3=yzx, 4=zxy, 5=zyx). "
+            + "Default 5 matches VTK image point-data flattening with X varying "
+            + "fastest and Z slowest.",
+        )
         self.register_argument(
             "--field",
             default="GrainID",
@@ -75,17 +90,41 @@ class CubitVtkToExodusApp(CubitApp):
             + "If provided, Euler angle data are mapped and written in serial "
             + "segments sized from the generated Exodus filesize.",
         )
+        self.register_argument(
+            "--centroid-bbox-size",
+            default=None,
+            nargs="+",
+            type=float,
+            help="Optional centroid-centered clipping box size in the input VTK "
+            + "coordinate units. Provide either one value for an isotropic box or "
+            + "three values for x y z. The clipped volume is cached as a VTI file "
+            + "in the cubit case directory and reused when overwrite is False.",
+        )
+        self.register_argument(
+            "--min-grain-voxel-count",
+            default=10,
+            type=int,
+            help="Minimum connected grain-region voxel count to preserve before "
+            + "merging it into a neighboring grain.",
+        )
         super().parse_execute_arguments()
 
-    def get_vtk_file_data(self, vtk_file):
-        """Extract the data object from a VTK file
-        containing structured points"""
-        # read the VTK structured points file and extract the downsampled data
-        reader = vtkStructuredPointsReader()
+    @staticmethod
+    def load_vtk_image_data(vtk_file):
+        """Load legacy VTK structured points or XML image data."""
+
+        suffix = os.path.splitext(vtk_file)[1].lower()
+        if suffix == ".vti":
+            reader = vtkXMLImageDataReader()
+        else:
+            reader = vtkStructuredPointsReader()
         reader.SetFileName(vtk_file)
-        reader.ReadAllScalarsOn()
         reader.Update()
-        structured_points = reader.GetOutput()
+        return reader.GetOutput()
+
+    def get_vtk_file_data(self, vtk_file):
+        """Extract the downsampled data object from a VTK/VTI image file."""
+        structured_points = self.load_vtk_image_data(vtk_file)
         extractor = vtkExtractVOI()
         extractor.SetInputData(structured_points)
         extractor.SetVOI(structured_points.GetExtent())
@@ -95,12 +134,109 @@ class CubitVtkToExodusApp(CubitApp):
         extractor.Update()
         return extractor.GetOutput()
 
+    def get_centroid_bbox_size(self):
+        """Return the configured centroid clip size as x, y, z lengths."""
+
+        bbox_size = self.args.centroid_bbox_size
+        if bbox_size is None:
+            return None
+        if len(bbox_size) == 1:
+            bbox_size = bbox_size * 3
+        elif len(bbox_size) != 3:
+            raise ValueError(
+                "--centroid-bbox-size must provide either one value or three values"
+            )
+        bbox_size = tuple(float(x) for x in bbox_size)
+        if any(x <= 0 for x in bbox_size):
+            raise ValueError("--centroid-bbox-size values must be greater than zero")
+        return bbox_size
+
+    def get_centroid_clip_voi(self, vtk_data):
+        """Return a centroid-centered VOI for the configured bounding box."""
+
+        bbox_size = self.get_centroid_bbox_size()
+        if bbox_size is None:
+            return None
+
+        bounds = vtk_data.GetBounds()
+        center = vtk_data.GetCenter()
+        extent = vtk_data.GetExtent()
+        origin = vtk_data.GetOrigin()
+        spacing = vtk_data.GetSpacing()
+
+        voi = []
+        for axis in range(3):
+            axis_min = bounds[2 * axis]
+            axis_max = bounds[2 * axis + 1]
+            clip_half_width = 0.5 * bbox_size[axis]
+            clip_min = max(axis_min, center[axis] - clip_half_width)
+            clip_max = min(axis_max, center[axis] + clip_half_width)
+            axis_spacing = abs(spacing[axis])
+            if axis_spacing == 0:
+                raise ValueError("Cannot clip VTK image data with zero spacing")
+            axis_start = max(
+                extent[2 * axis],
+                int(np.ceil((clip_min - origin[axis]) / axis_spacing)),
+            )
+            axis_stop = min(
+                extent[2 * axis + 1],
+                int(np.floor((clip_max - origin[axis]) / axis_spacing)),
+            )
+            if axis_start > axis_stop:
+                axis_center = int(round((center[axis] - origin[axis]) / axis_spacing))
+                axis_center = min(
+                    max(axis_center, extent[2 * axis]),
+                    extent[2 * axis + 1],
+                )
+                axis_start = axis_center
+                axis_stop = axis_center
+            voi.extend([axis_start, axis_stop])
+        return tuple(voi)
+
+    @staticmethod
+    def get_clipped_vti_path(case_directory):
+        """Return the cache path for a centroid-clipped VTI file."""
+
+        return os.path.join(case_directory, "centroid_clip.vti")
+
+    def write_clipped_vti(self, vtk_file, clipped_vti_file):
+        """Clip the source image around its centroid and write a cached VTI file."""
+
+        vtk_data = self.load_vtk_image_data(vtk_file)
+        voi = self.get_centroid_clip_voi(vtk_data)
+        if voi is None:
+            raise ValueError(
+                "Centroid clip requested without a valid bounding box size"
+            )
+
+        extractor = vtkExtractVOI()
+        extractor.SetInputData(vtk_data)
+        extractor.SetVOI(*voi)
+        extractor.Update()
+
+        writer = vtkXMLImageDataWriter()
+        writer.SetFileName(clipped_vti_file)
+        writer.SetInputData(extractor.GetOutput())
+        writer.Write()
+
+    def prepare_vtk_input_file(self, vtk_file, case_directory):
+        """Return the input image file to mesh, caching a centroid clip when requested."""
+
+        if self.get_centroid_bbox_size() is None:
+            return vtk_file
+
+        clipped_vti_file = self.get_clipped_vti_path(case_directory)
+        if os.path.exists(clipped_vti_file) and (not self.args.overwrite):
+            return clipped_vti_file
+
+        self.write_clipped_vti(vtk_file, clipped_vti_file)
+        return clipped_vti_file
+
     def generate_material_id_file(self, vtk_data_array, output_directory):
         """Convert a VTK file with a material ID field into a Cubit-compatible material
         id file (.spn) and return dictionary with metadata"""
 
-        # original list of grain ids
-        gids = vtk_to_numpy(vtk_data_array.GetPointData().GetArray(self.args.field))
+        gids = self.merge_small_grain_regions(vtk_data_array)
 
         # Get unique integers for each id in the `field` for .spn file
         # (removes issues in the case where ids are negative)
@@ -124,6 +260,169 @@ class CubitVtkToExodusApp(CubitApp):
 
         return new_id_dict
 
+    @staticmethod
+    def get_overlay_grid_bounds(vtk_data):
+        """Return overlay-grid bounds that align Sculpt cells to VTK sample points."""
+
+        origin = vtk_data.GetOrigin()
+        spacing = vtk_data.GetSpacing()
+        dimensions = vtk_data.GetDimensions()
+
+        bounds = []
+        for axis in range(3):
+            axis_spacing = float(spacing[axis])
+            axis_origin = float(origin[axis])
+            axis_dim = int(dimensions[axis])
+            if axis_dim <= 0:
+                raise ValueError("VTK image data dimensions must be greater than zero")
+
+            axis_min = axis_origin - 0.5 * axis_spacing
+            axis_max = axis_origin + (axis_dim - 0.5) * axis_spacing
+            bounds.extend([min(axis_min, axis_max), max(axis_min, axis_max)])
+        return tuple(bounds)
+
+    @staticmethod
+    def format_sculpt_float(value):
+        """Format overlay-grid coordinates as plain decimal floats for Sculpt."""
+
+        formatted = format(float(value), ".15f").rstrip("0")
+        if formatted.endswith("."):
+            formatted += "0"
+        return formatted
+
+    @staticmethod
+    def get_region_neighbor_counts(grain_ids, region_mask):
+        """Count face-adjacent neighboring grain ids for a connected region."""
+
+        neighbor_counts = {}
+        for axis in range(3):
+            leading = [slice(None)] * 3
+            trailing = [slice(None)] * 3
+            leading[axis] = slice(1, None)
+            trailing[axis] = slice(None, -1)
+            leading = tuple(leading)
+            trailing = tuple(trailing)
+
+            before_neighbors = grain_ids[trailing][
+                region_mask[leading] & ~region_mask[trailing]
+            ]
+            after_neighbors = grain_ids[leading][
+                region_mask[trailing] & ~region_mask[leading]
+            ]
+            for neighbor_ids in (before_neighbors, after_neighbors):
+                if neighbor_ids.size == 0:
+                    continue
+                neighbor_values, counts = np.unique(neighbor_ids, return_counts=True)
+                for neighbor_value, count in zip(neighbor_values, counts):
+                    neighbor_counts[neighbor_value] = neighbor_counts.get(
+                        neighbor_value, 0
+                    ) + int(count)
+
+        return neighbor_counts
+
+    @staticmethod
+    def get_replacement_grain_id(neighbor_counts):
+        """Choose the neighboring grain id with the strongest shared interface."""
+
+        if len(neighbor_counts) == 0:
+            return None
+
+        return min(
+            neighbor_counts,
+            key=lambda neighbor_gid: (-neighbor_counts[neighbor_gid], neighbor_gid),
+        )
+
+    def merge_small_grain_regions(self, vtk_data):
+        """Merge small regions and enforce one contiguous region per grain id."""
+
+        min_grain_voxel_count = self.args.min_grain_voxel_count
+        if min_grain_voxel_count <= 0:
+            raise ValueError("--min-grain-voxel-count must be greater than zero")
+
+        grain_array = vtk_data.GetPointData().GetArray(self.args.field)
+        if grain_array is None:
+            raise ValueError(f'VTK point-data array "{self.args.field}" was not found')
+
+        gids = vtk_to_numpy(grain_array)
+        if gids.size == 0:
+            return gids
+
+        nx, ny, nz = vtk_data.GetDimensions()
+        grain_ids = gids.reshape((nz, ny, nx))
+        vtk_data.GetPointData().SetActiveScalars(self.args.field)
+
+        connectivity_filter = vtkImageConnectivityFilter()
+        connectivity_filter.SetInputData(vtk_data)
+        connectivity_filter.SetExtractionModeToAllRegions()
+        connectivity_filter.SetLabelModeToSizeRank()
+
+        while True:
+            merged_region = False
+            unique_gids = np.unique(gids)
+            for gid in unique_gids:
+                grain_array.Modified()
+                vtk_data.Modified()
+                connectivity_filter.SetScalarRange(gid, gid)
+                connectivity_filter.Update()
+
+                if connectivity_filter.GetNumberOfExtractedRegions() == 0:
+                    continue
+
+                region_labels = vtk_to_numpy(
+                    connectivity_filter.GetOutput().GetPointData().GetScalars()
+                ).reshape((nz, ny, nx))
+                region_sizes = vtk_to_numpy(
+                    connectivity_filter.GetExtractedRegionSizes()
+                )
+                enforce_single_region = (
+                    connectivity_filter.GetNumberOfExtractedRegions() > 1
+                )
+                for region_label, region_size in enumerate(region_sizes, start=1):
+                    if region_size >= min_grain_voxel_count and not (
+                        enforce_single_region and region_label > 1
+                    ):
+                        continue
+
+                    region_mask = region_labels == region_label
+                    neighbor_counts = self.get_region_neighbor_counts(
+                        grain_ids, region_mask
+                    )
+                    neighbor_counts.pop(gid, None)
+                    replacement_gid = self.get_replacement_grain_id(neighbor_counts)
+                    if replacement_gid is None:
+                        continue
+
+                    grain_ids[region_mask] = replacement_gid
+                    merged_region = True
+
+            if not merged_region:
+                break
+
+        return gids
+
+    def build_sculpt_command(self, exodus_prefix, vtk_data):
+        """Build the Sculpt command for meshing the SPN volume."""
+
+        nx, ny, nz = vtk_data.GetDimensions()
+        sculpt_flag_str = self.args.sculptflags.replace("'", "").replace('"', "")
+        sculpt_flags = shlex.split(sculpt_flag_str)
+        return [
+            self.exe_psculpt,
+            "-isp",
+            self.args.spn,
+            "-spo",
+            self.args.spn_xyz_order,
+            "-e",
+            exodus_prefix,
+            "-x",
+            nx,
+            "-y",
+            ny,
+            "-z",
+            nz,
+            *sculpt_flags,
+        ]
+
     def mesh_vtk_file(self, vtk_file, exodus_file):
         """Meshes a VTK file containing a structured points array based on the specified
         array name (self.args.field)"""
@@ -138,32 +437,18 @@ class CubitVtkToExodusApp(CubitApp):
 
         # Pre-process VTK data file
         case_directory = os.path.dirname(exodus_file)
-        data = self.get_vtk_file_data(vtk_file)
-        nx, ny, nz = data.GetDimensions()
+        mesh_input_file = self.prepare_vtk_input_file(vtk_file, case_directory)
+        data = self.get_vtk_file_data(mesh_input_file)
         new_id_dict = self.generate_material_id_file(data, case_directory)
 
         # Set exodus variables
         exodus_prefix = os.path.basename(exodus_file).replace(".e", "")
-        sculpt_flags = self.args.sculptflags.split(" ")
+        sculpt_cmd = self.build_sculpt_command(exodus_prefix, data)
 
         # Change working directory for psculpt, then generate mesh in parallel
         with working_directory(case_directory):
             log_file = os.path.join(case_directory, "psculpt.log")
             with open(log_file, "w", encoding="utf-8") as f:
-                sculpt_cmd = [
-                    self.exe_psculpt,
-                    "-isp",
-                    self.args.spn,
-                    "-e",
-                    exodus_prefix,
-                    "-x",
-                    nx,
-                    "-y",
-                    ny,
-                    "-z",
-                    nz,
-                    *sculpt_flags,
-                ]
                 process = self.start_subprocess_with_mpi_args(
                     [str(x) for x in sculpt_cmd],
                     stdout=f,
@@ -201,9 +486,12 @@ class CubitVtkToExodusApp(CubitApp):
                     # > the application ExaCA-specific. Another method of passing
                     # > grain orientation is needed if this app is to be generalized
                     # > to other microstructure simulations.
-                    exaca_input_file = os.path.join(
-                        os.path.dirname(vtk_file), self.args.exacainput
-                    )
+                    if Path(self.args.exacainput).is_absolute():
+                        exaca_input_file = self.args.exacainput
+                    else:
+                        exaca_input_file = os.path.join(
+                            os.path.dirname(vtk_file), self.args.exacainput
+                        )
                     with open(exaca_input_file, "r", encoding="utf-8") as f:
                         exaca_inputs = json.load(f)
                     ref_id_file = exaca_inputs["GrainOrientationFile"]

--- a/tests/test_app_argument_parsing.py
+++ b/tests/test_app_argument_parsing.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 
 from myna.application.cubit.cubit import CubitApp
+from myna.application.cubit.vtk_to_exodus_region.app import CubitVtkToExodusApp
 from myna.application.deer.deer import DeerApp
 from myna.application.exaca.exaca import ExaCA
 from myna.application.openfoam.mesh_part_vtk.app import OpenFOAMMeshPartVTK
@@ -314,6 +315,26 @@ def test_cubit_stage_parsers_are_idempotent(monkeypatch, stage_calls):
 
     assert _count_option_actions(app.parser, "--cubitpath") == 1
     assert app.args.cubitpath is None
+
+
+@pytest.mark.parametrize(
+    "stage_calls",
+    [
+        ("parse_execute_arguments", "parse_configure_arguments"),
+        ("parse_configure_arguments", "parse_execute_arguments"),
+        ("parse_execute_arguments", "parse_execute_arguments"),
+    ],
+)
+def test_cubit_vtk_to_exodus_stage_parsers_are_idempotent(monkeypatch, stage_calls):
+    monkeypatch.setattr(sys, "argv", ["test"])
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+
+    for stage_call in stage_calls:
+        getattr(app, stage_call)()
+
+    assert _count_option_actions(app.parser, "--orientation-segment-gb") == 1
+    assert app.args.orientation_segment_gb is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app_argument_parsing.py
+++ b/tests/test_app_argument_parsing.py
@@ -333,8 +333,14 @@ def test_cubit_vtk_to_exodus_stage_parsers_are_idempotent(monkeypatch, stage_cal
     for stage_call in stage_calls:
         getattr(app, stage_call)()
 
+    assert _count_option_actions(app.parser, "--spn-xyz-order") == 1
     assert _count_option_actions(app.parser, "--orientation-segment-gb") == 1
+    assert _count_option_actions(app.parser, "--centroid-bbox-size") == 1
+    assert _count_option_actions(app.parser, "--min-grain-voxel-count") == 1
+    assert app.args.spn_xyz_order == 5
     assert app.args.orientation_segment_gb is None
+    assert app.args.centroid_bbox_size is None
+    assert app.args.min_grain_voxel_count == 10
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cubit_vtk_to_exodus_region_behavior.py
+++ b/tests/test_cubit_vtk_to_exodus_region_behavior.py
@@ -342,7 +342,7 @@ def test_generate_material_id_file_merges_small_disconnected_grain_regions(
     np.testing.assert_array_equal(spn_ids, np.ones(16, dtype=np.int32))
 
 
-def test_build_sculpt_command_sets_explicit_spn_xyz_order(monkeypatch):
+def test_build_sculpt_command_sets_spn_xyz_order(monkeypatch):
     monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
     app = CubitVtkToExodusApp()
     app.exe_psculpt = "psculpt"
@@ -376,18 +376,6 @@ def test_build_sculpt_command_sets_explicit_spn_xyz_order(monkeypatch):
         4,
         "-z",
         5,
-        "--xmin",
-        "9.0",
-        "--ymin",
-        "-6.0",
-        "--zmin",
-        "99.0",
-        "--xmax",
-        "15.0",
-        "--ymax",
-        "2.0",
-        "--zmax",
-        "109.0",
         "-S",
         "2",
         "-CS",

--- a/tests/test_cubit_vtk_to_exodus_region_behavior.py
+++ b/tests/test_cubit_vtk_to_exodus_region_behavior.py
@@ -11,6 +11,8 @@ from types import SimpleNamespace
 import numpy as np
 import pandas as pd
 import pytest
+from vtk import vtkImageData
+from vtkmodules.util.numpy_support import numpy_to_vtk
 
 from myna.application.cubit.cubit import CubitApp
 from myna.application.cubit.vtk_to_exodus_region.app import CubitVtkToExodusApp
@@ -37,6 +39,43 @@ class FakeExodusDataset:
         variable = FakeVariable(dtype, self.size)
         self.variables[variable_name] = variable
         return variable
+
+
+class FakeStructuredImage:
+    def __init__(self, bounds, center, extent, origin, spacing, dimensions=None):
+        self._bounds = bounds
+        self._center = center
+        self._extent = extent
+        self._origin = origin
+        self._spacing = spacing
+        self._dimensions = dimensions
+
+    def GetBounds(self):
+        return self._bounds
+
+    def GetCenter(self):
+        return self._center
+
+    def GetExtent(self):
+        return self._extent
+
+    def GetOrigin(self):
+        return self._origin
+
+    def GetSpacing(self):
+        return self._spacing
+
+    def GetDimensions(self):
+        return self._dimensions
+
+
+def make_vtk_image_data(dimensions, grain_ids, field_name="GrainID"):
+    image_data = vtkImageData()
+    image_data.SetDimensions(*dimensions)
+    vtk_array = numpy_to_vtk(np.asarray(grain_ids), deep=1)
+    vtk_array.SetName(field_name)
+    image_data.GetPointData().SetScalars(vtk_array)
+    return image_data
 
 
 @pytest.mark.parametrize(
@@ -97,3 +136,268 @@ def test_get_orientation_chunk_size_rejects_non_positive_segment_size(
 
     with pytest.raises(ValueError, match="orientation-segment-gb"):
         app.get_orientation_chunk_size("/tmp/unused.e", 10)
+
+
+def test_merge_small_grain_regions_rejects_non_positive_threshold(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(field="GrainID", min_grain_voxel_count=0)
+    vtk_data = make_vtk_image_data((1, 1, 1), np.array([1], dtype=np.int32))
+
+    with pytest.raises(ValueError, match="min-grain-voxel-count"):
+        app.merge_small_grain_regions(vtk_data)
+
+
+def test_merge_small_grain_regions_merges_secondary_disconnected_region(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(field="GrainID", min_grain_voxel_count=1)
+    vtk_data = make_vtk_image_data(
+        (5, 3, 1),
+        np.array(
+            [
+                1,
+                1,
+                2,
+                1,
+                1,
+                1,
+                1,
+                2,
+                3,
+                3,
+                1,
+                1,
+                2,
+                3,
+                3,
+            ],
+            dtype=np.int32,
+        ),
+    )
+
+    merged = app.merge_small_grain_regions(vtk_data).reshape((1, 3, 5))
+
+    expected = np.array(
+        [
+            [
+                [1, 1, 2, 3, 3],
+                [1, 1, 2, 3, 3],
+                [1, 1, 2, 3, 3],
+            ]
+        ],
+        dtype=np.int32,
+    )
+    np.testing.assert_array_equal(merged, expected)
+
+
+def test_get_replacement_grain_id_prefers_most_shared_faces_then_lowest_id():
+    replacement_gid = CubitVtkToExodusApp.get_replacement_grain_id({7: 4, 5: 4, 9: 2})
+
+    assert replacement_gid == 5
+
+
+def test_get_centroid_bbox_size_supports_scalar_and_xyz(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+
+    app.args = SimpleNamespace(centroid_bbox_size=[2.5])
+    assert app.get_centroid_bbox_size() == pytest.approx((2.5, 2.5, 2.5))
+
+    app.args = SimpleNamespace(centroid_bbox_size=[2.5, 3.5, 4.5])
+    assert app.get_centroid_bbox_size() == pytest.approx((2.5, 3.5, 4.5))
+
+
+@pytest.mark.parametrize("bbox_size", ([1.0, 2.0], [1.0, -2.0, 3.0]))
+def test_get_centroid_bbox_size_rejects_invalid_values(monkeypatch, bbox_size):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(centroid_bbox_size=bbox_size)
+
+    with pytest.raises(ValueError, match="centroid-bbox-size"):
+        app.get_centroid_bbox_size()
+
+
+def test_get_centroid_clip_voi_centers_and_clamps(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(centroid_bbox_size=[4.0, 6.0, 8.0])
+    vtk_data = FakeStructuredImage(
+        bounds=(0.0, 9.0, 0.0, 19.0, 0.0, 29.0),
+        center=(4.5, 9.5, 14.5),
+        extent=(0, 9, 0, 19, 0, 29),
+        origin=(0.0, 0.0, 0.0),
+        spacing=(1.0, 1.0, 1.0),
+    )
+
+    voi = app.get_centroid_clip_voi(vtk_data)
+
+    assert voi == (3, 6, 7, 12, 11, 18)
+
+
+def test_prepare_vtk_input_file_reuses_cached_clip(monkeypatch, tmp_path):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(centroid_bbox_size=[5.0], overwrite=False)
+
+    case_dir = tmp_path / "case"
+    case_dir.mkdir()
+    cached_vti = case_dir / "centroid_clip.vti"
+    cached_vti.write_text("cached", encoding="utf-8")
+
+    write_calls = []
+    monkeypatch.setattr(
+        app,
+        "write_clipped_vti",
+        lambda vtk_file, clipped_vti_file: write_calls.append(
+            (vtk_file, clipped_vti_file)
+        ),
+    )
+
+    vtk_input = app.prepare_vtk_input_file("microstructure.vtk", str(case_dir))
+
+    assert vtk_input == str(cached_vti)
+    assert write_calls == []
+
+
+def test_prepare_vtk_input_file_writes_clip_when_needed(monkeypatch, tmp_path):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(centroid_bbox_size=[5.0], overwrite=False)
+
+    case_dir = tmp_path / "case"
+    case_dir.mkdir()
+    write_calls = []
+    monkeypatch.setattr(
+        app,
+        "write_clipped_vti",
+        lambda vtk_file, clipped_vti_file: write_calls.append(
+            (vtk_file, clipped_vti_file)
+        ),
+    )
+
+    vtk_input = app.prepare_vtk_input_file("microstructure.vtk", str(case_dir))
+
+    assert vtk_input == str(case_dir / "centroid_clip.vti")
+    assert write_calls == [("microstructure.vtk", str(case_dir / "centroid_clip.vti"))]
+
+
+def test_get_overlay_grid_bounds_aligns_cells_to_vtk_sample_points(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    vtk_data = FakeStructuredImage(
+        bounds=(10.0, 14.0, -5.0, 1.0, 100.0, 108.0),
+        center=(12.0, -2.0, 104.0),
+        extent=(0, 2, 0, 3, 0, 4),
+        origin=(10.0, -5.0, 100.0),
+        spacing=(2.0, 2.0, 2.0),
+        dimensions=(3, 4, 5),
+    )
+
+    bounds = app.get_overlay_grid_bounds(vtk_data)
+
+    assert bounds == pytest.approx((9.0, 15.0, -6.0, 2.0, 99.0, 109.0))
+
+
+def test_generate_material_id_file_merges_small_disconnected_grain_regions(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(
+        field="GrainID",
+        spn="material_ids.spn",
+        min_grain_voxel_count=10,
+    )
+
+    vtk_data = make_vtk_image_data(
+        (4, 4, 1),
+        np.array(
+            [
+                2,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                2,
+            ],
+            dtype=np.int32,
+        ),
+    )
+
+    new_id_dict = app.generate_material_id_file(vtk_data, str(tmp_path))
+
+    assert new_id_dict == {1: 1}
+    spn_ids = np.loadtxt(tmp_path / "material_ids.spn", dtype=np.int32)
+    np.testing.assert_array_equal(spn_ids, np.ones(16, dtype=np.int32))
+
+
+def test_build_sculpt_command_sets_explicit_spn_xyz_order(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.exe_psculpt = "psculpt"
+    vtk_data = FakeStructuredImage(
+        bounds=(10.0, 14.0, -5.0, 1.0, 100.0, 108.0),
+        center=(12.0, -2.0, 104.0),
+        extent=(0, 2, 0, 3, 0, 4),
+        origin=(10.0, -5.0, 100.0),
+        spacing=(2.0, 2.0, 2.0),
+        dimensions=(3, 4, 5),
+    )
+    app.args = SimpleNamespace(
+        spn="material_ids.spn",
+        spn_xyz_order=5,
+        sculptflags="-S 2 -CS 5",
+    )
+
+    sculpt_cmd = app.build_sculpt_command("mesh", vtk_data)
+
+    assert sculpt_cmd == [
+        "psculpt",
+        "-isp",
+        "material_ids.spn",
+        "-spo",
+        5,
+        "-e",
+        "mesh",
+        "-x",
+        3,
+        "-y",
+        4,
+        "-z",
+        5,
+        "--xmin",
+        "9.0",
+        "--ymin",
+        "-6.0",
+        "--zmin",
+        "99.0",
+        "--xmax",
+        "15.0",
+        "--ymax",
+        "2.0",
+        "--zmax",
+        "109.0",
+        "-S",
+        "2",
+        "-CS",
+        "5",
+    ]
+
+
+def test_format_sculpt_float_avoids_scientific_notation(monkeypatch):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+
+    assert app.format_sculpt_float(1.2e-6) == "0.0000012"
+    assert app.format_sculpt_float(-3.4e5) == "-340000.0"

--- a/tests/test_cubit_vtk_to_exodus_region_behavior.py
+++ b/tests/test_cubit_vtk_to_exodus_region_behavior.py
@@ -1,0 +1,99 @@
+#
+# Copyright (c) Oak Ridge National Laboratory.
+#
+# This file is part of Myna. For details, see the top-level license
+# at https://github.com/ORNL-MDF/Myna/LICENSE.md.
+#
+# License: 3-clause BSD, see https://opensource.org/licenses/BSD-3-Clause.
+#
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from myna.application.cubit.cubit import CubitApp
+from myna.application.cubit.vtk_to_exodus_region.app import CubitVtkToExodusApp
+
+
+class FakeVariable:
+    def __init__(self, dtype, size):
+        self.dtype = np.dtype(dtype)
+        self.data = np.zeros(size, dtype=self.dtype)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
+
+
+class FakeExodusDataset:
+    def __init__(self, size):
+        self.size = size
+        self.variables = {}
+
+    def createVariable(self, variable_name, dtype, _dims):
+        variable = FakeVariable(dtype, self.size)
+        self.variables[variable_name] = variable
+        return variable
+
+
+@pytest.mark.parametrize(
+    "segment_size_gb,file_size_gb",
+    [
+        (None, 0.01),
+        (1.0, 2.5),
+    ],
+)
+def test_write_exodus_block_data_supports_single_step_and_segmented_mapping(
+    monkeypatch, tmp_path, segment_size_gb, file_size_gb
+):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(orientation_segment_gb=segment_size_gb)
+
+    exodus_file = tmp_path / "mesh.e"
+    with open(exodus_file, "wb") as f:
+        f.truncate(int(file_size_gb * (1024**3)))
+
+    elem_orig_ids = np.array([0, 1, 2, -3, 4], dtype=np.int64)
+    df_ref_ids = pd.DataFrame(
+        {
+            "phi1": [0.1, 0.2, 0.3],
+            "Phi": [1.1, 1.2, 1.3],
+            "phi2": [2.1, 2.2, 2.3],
+        }
+    )
+    exodus_object = FakeExodusDataset(len(elem_orig_ids))
+
+    app.write_exodus_block_data(
+        exodus_object, elem_orig_ids, df_ref_ids, str(exodus_file)
+    )
+
+    np.testing.assert_array_equal(
+        exodus_object.variables["id_array"].data, elem_orig_ids
+    )
+    np.testing.assert_allclose(
+        exodus_object.variables["euler_bunge_zxz_phi1"].data,
+        np.array([0.1, 0.1, 0.2, 0.3, 0.1]),
+    )
+    np.testing.assert_allclose(
+        exodus_object.variables["euler_bunge_zxz_Phi"].data,
+        np.array([1.1, 1.1, 1.2, 1.3, 1.1]),
+    )
+    np.testing.assert_allclose(
+        exodus_object.variables["euler_bunge_zxz_phi2"].data,
+        np.array([2.1, 2.1, 2.2, 2.3, 2.1]),
+    )
+
+
+def test_get_orientation_chunk_size_rejects_non_positive_segment_size(
+    monkeypatch,
+):
+    monkeypatch.setattr(CubitApp, "_validate_cubit_executables", lambda self: None)
+    app = CubitVtkToExodusApp()
+    app.args = SimpleNamespace(orientation_segment_gb=0.0)
+
+    with pytest.raises(ValueError, match="orientation-segment-gb"):
+        app.get_orientation_chunk_size("/tmp/unused.e", 10)


### PR DESCRIPTION
## Summary
<!-- Provide a concise description of this pull request and what it changes. -->
Final stacked PR from the `feat/thesis/eol-temp` split. This isolates the remaining Cubit-focused work: lower-memory orientation mapping, added meshing controls, and the associated example updates.

## Related issues
<!--
If this PR addresses one or more issues, list them here with the appropriate keywords:
- Closes #12
- Related to #13
- Depends on #14
If there are no related issues, state that explicitly:
- No related issues.
-->
- No related issues.


## Details
<!--
Depending on the pull request type, please include the relevant details here:
- Bug fix (`fix`): summarize the bug, how it was reproduced, the root cause, and why this fix addresses it.
- New feature (`feat`): describe the user problem, the capability added, and the workflow or use case it enables.
- Performance improvement (`perf`): describe the bottleneck or performance problem and the improvement this change is intended to deliver.
- Refactor (`refactor`): describe the maintainability or architectural problem being addressed and the rationale for the refactor.
- Chore (`chore`): describe the project, tooling, documentation, configuration, or maintenance goal this change addresses.
Explain how this change was implemented and which parts of the application were changed.
Focus on the behavior change, structural change, optimization strategy, or workflow outcome rather than just a file list.
-->
This PR adds a serial orientation-mapping mode for `vtk_to_exodus_region` controlled by `--orientation-segment-gb`, allowing large cases to trade throughput for reduced peak memory during orientation transfer.

It also adds additional meshing control arguments for Cubit/SPN meshing workflows and extends the behavior tests and parser coverage for those options.

The example updates that depend on those Cubit options are carried here so the final stacked branch preserves the original feature branch behavior while keeping the Deer container support isolated to PR 1.

Included commits:
- `5904ea1` `feat(cubit): serialize orientation mapping to reduce memory use`
- `b7b3e8b` `feat(cubit): add meshing control arguments`

## Impact
<!--
Describe the impact of this change on the project. Consider functionality, workflows, performance, maintainability, and user experience.
If the change is intended to have no impact on behavior, state that explicitly.
If this change is a performance improvement, include any measured impact here or in the Testing strategy details.
Describe the overall risk level of these changes (High / Medium / Low) and the rationale for that assessment.
If architecture-sensitive paths changed only to extend expected extension points and
no architecture or developer-doc update is needed, include a line like:
Architecture/docs: no update needed - this extends an existing component hook without changing boundaries.
-->
This changes Cubit workflow behavior by adding new execution-time controls and a lower-memory path for orientation mapping. It should improve operability for larger meshes while preserving the existing workflow for users who do not opt into the new arguments.

Risk level: Medium. The changes are concentrated in one Cubit app, but they affect meshing and orientation-transfer behavior and therefore deserve careful review of the new execution paths.

Architecture/docs: no update needed - this extends an existing Cubit application with additional execution controls without changing subsystem boundaries.

## Testing strategy
<!--
Describe the testing strategy for this change and include any relevant details about the testing environment or configuration:
- OS/shell
- Python version
- Install method (`uv`/`pip`/`Docker`)
- Command or workflow tested
- External application version if relevant
- Hardware specs if performance-sensitive
If the change is covered by the CI test suite, state that explicitly.
If manual testing was performed, describe the testing process and results.
-->
Commit hooks passed during commit creation.

Covered by focused tests in CI-relevant areas:
- `tests/test_cubit_vtk_to_exodus_region_behavior.py`
- `tests/test_app_argument_parsing.py`

Stack context:
- Base branch: `stack/thesis`
- PR branch: `stack/cubit`
- Stack position: 3 of 3


## Checklist

- [x] Architecture/docs impact considered. Updated `ARCHITECTURE.md` and/or
      developer docs where needed, or explained why not.
