### PR TITLE
add option to skip layers if they are not present

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,9 @@ extracts metadata. New shared workflow code should prefer `WorkflowContext`,
 - **Input file**: YAML or JSON workflow settings loaded by
   `myna.core.workflow.load_input`. Accepted suffixes are `.yaml`, `.json` for the main input
   files and Myna workspaces can be included with `.yaml`, `.json`, `.myna-workspace`,
-  and `.myna-workspace-json` suffixes.
+  and `.myna-workspace-json` suffixes. The `myna` section carries workflow-wide
+  settings such as the optional `workspace` path and `ignore_missing_layers` flag used
+  by `myna config` to skip missing layer metadata for independent layer-wise cases.
 - **Workflow**: Ordered `steps` in an input file. The CLI can configure, run, and sync
   all steps or selected steps.
 - **Step**: A named workflow entry with a component `class`, an `application`, optional
@@ -162,6 +164,9 @@ Stage command-line arguments from the input file are still exposed through `sys.
 while each stage runs, preserving `argparse`-based app wrappers. For `sync`, Myna
 validates component outputs and delegates supported sync behavior to the selected
 database adapter while providing the active input file through `WorkflowContext`.
+When `myna.ignore_missing_layers` is true, `config` drops missing part-layer and
+build-region-layer cases from the configured case set, but region-layer steps still
+fail because their requested layers are not independent.
 
 ## Dependency Boundaries
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -116,6 +116,20 @@ regardless of if there is an existing application. This will allow you to test t
 correct metadata is being supplied to the case directories. When composing your
 input file, just provide an arbitrary name for the application, e.g., "test".
 
+For workflows that request explicit layer lists, `myna config` normally fails when a
+requested layer cannot be loaded from the database. Users can opt into best-effort
+configuration for independent layer-wise cases with:
+
+```yaml
+myna:
+  ignore_missing_layers: true
+```
+
+That flag only applies to configure-time `LayerFile` metadata for workflows whose
+cases are independent by layer, such as part-layer or build-region-layer steps.
+Region-layer steps still fail when any requested layer is missing because those cases
+depend on the complete requested layer set.
+
 ### Documentation impact for component types
 
 Adding a new component class or component type under `src/myna/core/components/` uses

--- a/examples/cases/solidification_part/input.yaml
+++ b/examples/cases/solidification_part/input.yaml
@@ -13,6 +13,7 @@ data:
     path: ../../databases
     parts:
       P5:
-        layers: [51]
+        layers: [51,200]
 myna:
   workspace: ../../workspaces/example-workspace.yaml
+  ignore_missing_layers: true

--- a/src/myna/core/workflow/config.py
+++ b/src/myna/core/workflow/config.py
@@ -21,6 +21,73 @@ import getpass
 from git import Repo, InvalidGitRepositoryError
 
 
+def _should_ignore_missing_layers(settings):
+    """Whether configure should skip missing layer metadata when possible."""
+
+    return bool(nested_get(settings, ["myna", "ignore_missing_layers"], False))
+
+
+def _can_skip_missing_layers(step_obj, settings):
+    """Whether the active step allows missing layers to be skipped."""
+
+    return (
+        _should_ignore_missing_layers(settings)
+        and "layer" in step_obj.types
+        and "region" not in step_obj.types
+    )
+
+
+def _is_missing_layer_error(error):
+    """Whether an error indicates missing layer-scoped metadata."""
+
+    return isinstance(error, (FileNotFoundError, LookupError, IndexError, TypeError))
+
+
+def _remove_missing_part_layer(settings, part, layer):
+    """Remove a missing layer from part-scoped configured data."""
+
+    layer_value = int(layer)
+    layer_key = str(layer)
+    part_settings = nested_get(settings, ["data", "build", "parts", part], {})
+    part_settings["layers"] = [
+        int(x)
+        for x in nested_get(part_settings, ["layers"], [])
+        if int(x) != layer_value
+    ]
+    nested_get(part_settings, ["layer_data"], {}).pop(layer_key, None)
+
+
+def _remove_missing_build_region_layer(settings, build_region, layer):
+    """Remove a missing layer from build-region configured data."""
+
+    layer_value = int(layer)
+    layer_key = str(layer)
+    build_region_settings = nested_get(
+        settings, ["data", "build", "build_regions", build_region], {}
+    )
+    build_region_settings["layerlist"] = [
+        int(x)
+        for x in nested_get(build_region_settings, ["layerlist"], [])
+        if int(x) != layer_value
+    ]
+    for part in nested_get(build_region_settings, ["partlist"], []):
+        nested_get(build_region_settings, ["parts", part, "layer_data"], {}).pop(
+            layer_key, None
+        )
+
+
+def _warn_for_skipped_layers(step_name, skipped_layers):
+    """Print a concise warning for layers skipped during configure."""
+
+    if not skipped_layers:
+        return
+
+    print(f'Warning: Step "{step_name}" skipped missing layer metadata for:')
+    for scope_name in sorted(skipped_layers):
+        layers = ", ".join(str(x) for x in sorted(skipped_layers[scope_name]))
+        print(f"  - {scope_name}: {layers}")
+
+
 # Parser comes from the top-level command parsing
 def parse(parser):
     """Main function for configuring a myna case from the command line"""
@@ -217,6 +284,7 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
             pass
 
         # Get the data requirements associated with that class
+        skipped_layers = {}
         for data_req in step_obj.data_requirements:
             # For each data requirements, lookup the corresponding data object
             data_class_name = metadata.return_data_class_name(data_req)
@@ -340,9 +408,27 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
                                     layer,
                                     data_req,
                                 ]
-                                set_layerfile_entry(
-                                    datatype, part, layer, settings, nested_layerkeys
-                                )
+                                try:
+                                    set_layerfile_entry(
+                                        datatype,
+                                        part,
+                                        layer,
+                                        settings,
+                                        nested_layerkeys,
+                                    )
+                                except Exception as error:  # pragma: no cover - re-raise path covered below
+                                    if not (
+                                        _can_skip_missing_layers(step_obj, settings)
+                                        and _is_missing_layer_error(error)
+                                    ):
+                                        raise
+                                    skipped_layers.setdefault(build_region, set()).add(
+                                        int(layer)
+                                    )
+                                    _remove_missing_build_region_layer(
+                                        settings, build_region, layer
+                                    )
+                                    break
                 else:
                     parts = nested_get(settings, ["data", "build", "parts"], {})
                     for part in parts.keys():
@@ -359,9 +445,18 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
                                 layer,
                                 data_req,
                             ]
-                            set_layerfile_entry(
-                                datatype, part, layer, settings, nested_keys
-                            )
+                            try:
+                                set_layerfile_entry(
+                                    datatype, part, layer, settings, nested_keys
+                                )
+                            except Exception as error:  # pragma: no cover - re-raise path covered below
+                                if not (
+                                    _can_skip_missing_layers(step_obj, settings)
+                                    and _is_missing_layer_error(error)
+                                ):
+                                    raise
+                                skipped_layers.setdefault(part, set()).add(int(layer))
+                                _remove_missing_part_layer(settings, part, layer)
 
                         # Check for layers in region dictionary
                         regions = nested_get(parts, [part, "regions"], {})
@@ -385,6 +480,8 @@ def config(input_file, output_file=None, show_avail=False, overwrite=False):
                                 set_layerfile_entry(
                                     datatype, part, layer, settings, nested_keys
                                 )
+
+        _warn_for_skipped_layers(step_name, skipped_layers)
 
         # Save data to step object
         step_obj.apply_settings(

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -14,6 +14,7 @@ import warnings
 
 import myna
 import myna.core.context as context_module
+import pytest
 import yaml
 
 from myna.core.workflow.load_input import load_input, write_input
@@ -149,3 +150,100 @@ def test_config_expands_layer_range_strings_in_written_input(tmp_path):
         for layer in raw_settings["data"]["build"]["parts"]["P5"]["layer_data"].keys()
     ) == [51, 52]
     assert len(raw_settings["data"]["output_paths"]["3dthesis"]) == 2
+
+
+def test_config_missing_part_layer_fails_without_ignore_flag(tmp_path):
+    example_path = CASES_DIR / "solidification_part_json"
+    tmp_dir = tmp_path / "solidification_part_json"
+    tmp_dir.mkdir()
+
+    source_settings = load_input(example_path / "input.yaml")
+    source_settings["data"]["build"]["parts"]["P5"]["layers"] = [51, 999]
+
+    input_file = tmp_dir / "input.yaml"
+    write_input(source_settings, input_file)
+
+    with pytest.raises(KeyError):
+        myna.core.workflow.config.config(os.fspath(input_file))
+
+
+def test_config_ignore_missing_part_layers_skips_missing_cases(tmp_path):
+    example_path = CASES_DIR / "solidification_part_json"
+    tmp_dir = tmp_path / "solidification_part_json"
+    tmp_dir.mkdir()
+
+    source_settings = load_input(example_path / "input.yaml")
+    source_settings["myna"]["ignore_missing_layers"] = True
+    source_settings["data"]["build"]["parts"]["P5"]["layers"] = [51, 999]
+
+    input_file = tmp_dir / "input.yaml"
+    write_input(source_settings, input_file)
+
+    myna.core.workflow.config.config(os.fspath(input_file))
+
+    raw_settings = yaml.safe_load(input_file.read_text(encoding="utf-8"))
+
+    assert raw_settings["myna"]["ignore_missing_layers"] is True
+    assert raw_settings["data"]["build"]["parts"]["P5"]["layers"] == [51]
+    assert sorted(
+        int(layer)
+        for layer in raw_settings["data"]["build"]["parts"]["P5"]["layer_data"].keys()
+    ) == [51]
+    assert len(raw_settings["data"]["output_paths"]["3dthesis"]) == 1
+    assert "/999/" not in raw_settings["data"]["output_paths"]["3dthesis"][0]
+
+
+def test_config_ignore_missing_build_region_layers_skips_missing_cases(tmp_path):
+    example_path = CASES_DIR / "solidification_build_region"
+    tmp_dir = tmp_path / "solidification_build_region"
+    tmp_dir.mkdir()
+
+    source_settings = load_input(example_path / "input.yaml")
+    source_settings["steps"] = [source_settings["steps"][0]]
+    source_settings["myna"]["ignore_missing_layers"] = True
+    source_settings["data"]["build"]["build_regions"] = {
+        "test_1": {"partlist": ["P5"], "layerlist": [51, 999]}
+    }
+    source_settings["data"]["build"]["parts"] = {"P5": {"layers": [51]}}
+
+    input_file = tmp_dir / "input.yaml"
+    write_input(source_settings, input_file)
+
+    myna.core.workflow.config.config(os.fspath(input_file))
+
+    raw_settings = yaml.safe_load(input_file.read_text(encoding="utf-8"))
+
+    assert raw_settings["data"]["build"]["build_regions"]["test_1"]["layerlist"] == [51]
+    assert sorted(
+        int(layer)
+        for layer in raw_settings["data"]["build"]["build_regions"]["test_1"]["parts"][
+            "P5"
+        ]["layer_data"].keys()
+    ) == [51]
+    assert len(raw_settings["data"]["output_paths"]["3dthesis"]) == 1
+
+
+def test_config_ignore_missing_layers_still_fails_for_region_steps(tmp_path):
+    example_path = CASES_DIR / "solidification_part_json"
+    tmp_dir = tmp_path / "solidification_region_json"
+    tmp_dir.mkdir()
+
+    source_settings = load_input(example_path / "input.yaml")
+    source_settings["myna"]["ignore_missing_layers"] = True
+    source_settings["steps"] = [
+        {
+            "additivefoam": {
+                "class": "solidification_region_reduced",
+                "application": "additivefoam",
+            }
+        }
+    ]
+    source_settings["data"]["build"]["parts"] = {
+        "P5": {"regions": {"r1": {"layers": [51, 999], "x": 0.2, "y": 0.021}}}
+    }
+
+    input_file = tmp_dir / "input.yaml"
+    write_input(source_settings, input_file)
+
+    with pytest.raises(KeyError):
+        myna.core.workflow.config.config(os.fspath(input_file))


### PR DESCRIPTION
## Summary
<!-- Provide a concise description of this pull request and what it changes. -->
This adds in the ability for the user to specify for Myna to skip any layers where the appropriate metadata cannot be found. In the `input.yaml` file for the Myna case, the user sets:

```yaml
myna:
  ignore_missing_layers: true
```

If the user specifies simulation for a part's layers `[0-100]` and the metadata for layer 42 is missing,
then the configured Myna case will be configured for `[0-41,43-100]`.
This is only for layer-specific simulation types, and region-type simulations will still throw an error for missing layers.

## Related issues
<!--
If this PR addresses one or more issues, list them here with the appropriate keywords:
- Closes #12
- Related to #13
- Depends on #14
If there are no related issues, state that explicitly:
- No related issues.
-->
- Closes #196 

## Details
<!--
Depending on the pull request type, please include the relevant details here:
- Bug fix (`fix`): summarize the bug, how it was reproduced, the root cause, and why this fix addresses it.
- New feature (`feat`): describe the user problem, the capability added, and the workflow or use case it enables.
- Performance improvement (`perf`): describe the bottleneck or performance problem and the improvement this change is intended to deliver.
- Refactor (`refactor`): describe the maintainability or architectural problem being addressed and the rationale for the refactor.
- Chore (`chore`): describe the project, tooling, documentation, configuration, or maintenance goal this change addresses.
Explain how this change was implemented and which parts of the application were changed.
Focus on the behavior change, structural change, optimization strategy, or workflow outcome rather than just a file list.
-->
- adds an opt-in level of flexibility for handling missing data in the database (either from data quality issue or from requesting data that doesn't exist)
- configured input file will remove the missing layers so that only `myna config` needs to be concerned with this behavior


## Impact
<!--
Describe the impact of this change on the project. Consider functionality, workflows, performance, maintainability, and user experience.
If the change is intended to have no impact on behavior, state that explicitly.
If this change is a performance improvement, include any measured impact here or in the Testing strategy details.
Describe the overall risk level of these changes (High / Medium / Low) and the rationale for that assessment.
If architecture-sensitive paths changed only to extend expected extension points and
no architecture or developer-doc update is needed, include a line like:
Architecture/docs: no update needed - this extends an existing component hook without changing boundaries.
-->
Low impact change: This is an opt-in behavior that does not change Myna's default behavior. It is limited to changing the `myna config` submodule.

## Testing strategy
<!--
Describe the testing strategy for this change and include any relevant details about the testing environment or configuration:
- OS/shell
- Python version
- Install method (`uv`/`pip`/`Docker`)
- Command or workflow tested
- External application version if relevant
- Hardware specs if performance-sensitive
If the change is covered by the CI test suite, state that explicitly.
If manual testing was performed, describe the testing process and results.
-->
Testing was done with with pytest, including the added test for this behavior, and with a manually run example case.

## Checklist

- [x] Architecture/docs impact considered. Updated `ARCHITECTURE.md` and/or
      developer docs where needed.
