### PR TITLE
chore(db/peregrine_hdf5): add laser power synonym and fix warning message text

### DIFF
--- a/src/myna/database/peregrine_hdf5.py
+++ b/src/myna/database/peregrine_hdf5.py
@@ -31,6 +31,7 @@ class PeregrineHDF5(PeregrineDB):
     synonyms = {
         "laser_power": [
             "parts/process_parameters/laser_power",
+            "parts/process_parameters/laser_beam_power",
             "parts/process_parameters/power",
             "parts/process_parameters/bulk_laser_power",
         ],
@@ -131,11 +132,11 @@ class PeregrineHDF5(PeregrineDB):
             # in some files. Assume that if the spot size is greater than 10
             # that it is stored in microns (not millimeters) and correct accordingly.
             if value > 10:
-                value = value * 1e-3
                 warn_msg = (
                     f"Large spot size detected ({value} mm),"
                     + f" assuming conversion um to mm (--> {value * 1e-3} mm)"
                 )
+                value = value * 1e-3
                 warnings.warn(warn_msg)
 
             return value


### PR DESCRIPTION
## Summary
<!-- Provide a concise description of this pull request and what it changes. -->
The Peregrine v2023-11 dataset has a different name for the laser power dictionary key, so it is added to the synonyms list for the PeregrineHDF5 database. Also, a warning message about spot size unit correction was moved to emit the warning with before/after corrected values that match the values used in the code.

## Related issues
<!--
If this PR addresses one or more issues, list them here with the appropriate keywords:
- Closes #12
- Related to #13
- Depends on #14
If there are no related issues, state that explicitly:
- No related issues.
-->
- No related issues

## Details
<!--
Depending on the pull request type, please include the relevant details here:
- Bug fix (`fix`): summarize the bug, how it was reproduced, the root cause, and why this fix addresses it.
- New feature (`feat`): describe the user problem, the capability added, and the workflow or use case it enables.
- Performance improvement (`perf`): describe the bottleneck or performance problem and the improvement this change is intended to deliver.
- Refactor (`refactor`): describe the maintainability or architectural problem being addressed and the rationale for the refactor.
- Chore (`chore`): describe the project, tooling, documentation, configuration, or maintenance goal this change addresses.
Explain how this change was implemented and which parts of the application were changed.
Focus on the behavior change, structural change, optimization strategy, or workflow outcome rather than just a file list.
-->
Summary contains all details.

## Impact
<!--
Describe the impact of this change on the project. Consider functionality, workflows, performance, maintainability, and user experience.
If the change is intended to have no impact on behavior, state that explicitly.
If this change is a performance improvement, include any measured impact here or in the Testing strategy details.
Describe the overall risk level of these changes (High / Medium / Low) and the rationale for that assessment.
If architecture-sensitive paths changed only to extend expected extension points and
no architecture or developer-doc update is needed, include a line like:
Architecture/docs: no update needed - this extends an existing component hook without changing boundaries.
-->
Low impact: syntax changes only, no behavior change

## Testing strategy
<!--
Describe the testing strategy for this change and include any relevant details about the testing environment or configuration:
- OS/shell
- Python version
- Install method (`uv`/`pip`/`Docker`)
- Command or workflow tested
- External application version if relevant
- Hardware specs if performance-sensitive
If the change is covered by the CI test suite, state that explicitly.
If manual testing was performed, describe the testing process and results.
-->
CI covers testing and I have manually run some workflows with this branch locally.

## Checklist

- [x] Architecture/docs impact considered. Updated `ARCHITECTURE.md` and/or
      developer docs where needed, or explained why not.
      
Architecture/docs: no update needed - no functional change.
