### PR TITLE
bug/thesis postprocessing

### DIFF
--- a/src/myna/application/thesis/melt_pool_geometry_part/app.py
+++ b/src/myna/application/thesis/melt_pool_geometry_part/app.py
@@ -13,6 +13,7 @@ import glob
 import os
 import shutil
 import tempfile
+from collections import OrderedDict
 from pathlib import Path
 import numpy as np
 import polars as pl
@@ -139,6 +140,37 @@ class ThesisMeltPoolGeometryPart(Thesis):
                     return self.SNAPSHOT_SAMPLING_MODE
                 break
         return self.SNAPSHOT_SAMPLING_MODE
+
+    @staticmethod
+    def _xy_grid_thesis_to_myna_mapping(segment_file):
+        """Map 3DThesis xy-grid output columns to the Myna melt-pool schema."""
+        with open(segment_file, encoding="utf-8") as fp:
+            header = fp.readline().strip().split(",")
+        available_columns = set(header)
+        candidate_columns = OrderedDict(
+            [
+                ("time (s)", ["tSol"]),
+                ("length (m)", ["MP_length", "MP_length_interp"]),
+                ("width (m)", ["MP_width", "MP_width_interp"]),
+                ("depth (m)", ["MP_depth", "MP_depth_interp"]),
+                ("x (m)", ["x"]),
+                ("y (m)", ["y"]),
+            ]
+        )
+        thesis_to_myna_mapping = {}
+        for myna_name, candidates in candidate_columns.items():
+            thesis_name = next(
+                (column for column in candidates if column in available_columns),
+                None,
+            )
+            if thesis_name is None:
+                missing_columns = ", ".join(candidates)
+                raise ValueError(
+                    f"Missing expected 3DThesis xy-grid column for {myna_name}: "
+                    f"{missing_columns}"
+                )
+            thesis_to_myna_mapping[thesis_name] = myna_name
+        return thesis_to_myna_mapping
 
     def parse_configure_arguments(self):
         self.register_argument(
@@ -313,14 +345,6 @@ class ThesisMeltPoolGeometryPart(Thesis):
                             f"{output_name}.Solidification.Final*.csv",
                         )
                         segment_files = sorted(glob.glob(result_pattern))
-                        thesis_to_myna_mapping = {
-                            "tSol": "time (s)",
-                            "MP_length": "length (m)",
-                            "MP_width": "width (m)",
-                            "MP_depth": "depth (m)",
-                            "x": "x (m)",
-                            "y": "y (m)",
-                        }
                     else:
                         snapshot_data_file = os.path.join(
                             segment_dir, "Data", "snapshot_data.csv"
@@ -338,10 +362,14 @@ class ThesisMeltPoolGeometryPart(Thesis):
                             "Beam X": "x (m)",
                             "Beam Y": "y (m)",
                         }
-                    thesis_schema = {
-                        k: myna_schema[v] for k, v in thesis_to_myna_mapping.items()
-                    }
                     for segment_file in segment_files:
+                        if sampling_mode == self.XY_GRID_SAMPLING_MODE:
+                            thesis_to_myna_mapping = (
+                                self._xy_grid_thesis_to_myna_mapping(segment_file)
+                            )
+                        thesis_schema = {
+                            k: myna_schema[v] for k, v in thesis_to_myna_mapping.items()
+                        }
                         df = pl.read_csv(segment_file, columns=list(thesis_schema))
                         df = df.cast(thesis_schema)
                         df = df.rename(thesis_to_myna_mapping)

--- a/src/myna/application/thesis/melt_pool_geometry_part/app.py
+++ b/src/myna/application/thesis/melt_pool_geometry_part/app.py
@@ -370,8 +370,11 @@ class ThesisMeltPoolGeometryPart(Thesis):
                         thesis_schema = {
                             k: myna_schema[v] for k, v in thesis_to_myna_mapping.items()
                         }
-                        df = pl.read_csv(segment_file, columns=list(thesis_schema))
-                        df = df.cast(thesis_schema)
+                        df = pl.read_csv(
+                            segment_file,
+                            columns=list(thesis_schema),
+                            schema_overrides=thesis_schema,
+                        )
                         df = df.rename(thesis_to_myna_mapping)
                         df = df.select(list(myna_schema))
                         df_all_segments = pl.concat([df_all_segments, df])

--- a/tests/test_thesis_app_behavior.py
+++ b/tests/test_thesis_app_behavior.py
@@ -1135,6 +1135,79 @@ def test_melt_pool_geometry_execute_exports_xy_grid_schema(monkeypatch, tmp_path
     ]
 
 
+def test_melt_pool_geometry_execute_exports_interpolated_xy_grid_schema(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(context_module, "_LEGACY_ENV_FALLBACK_WARNED", False)
+    output_path = tmp_path / "melt-pool-grid-interp.csv"
+    _configure_workflow_env(
+        monkeypatch,
+        tmp_path,
+        "melt_pool_geometry_part",
+        [str(output_path)],
+    )
+
+    case_dir = tmp_path / "case"
+    segment_dir = case_dir / "path_segment_000"
+    data_dir = segment_dir / "Data"
+    data_dir.mkdir(parents=True)
+    (segment_dir / "Mode.txt").write_text(
+        "Solidification\n{\n\tTracking\tSurface\n\tTimestep\t1e-4\n}\n",
+        encoding="utf-8",
+    )
+    (segment_dir / "ParamInput.txt").write_text(
+        "\tName\tthermal_3dthesis\n", encoding="utf-8"
+    )
+    (data_dir / "thermal_3dthesis.Solidification.Final.csv").write_text(
+        "x,y,z,tSol,MP_width_interp,MP_length_interp,MP_depth_interp\n"
+        "0.2,0.4,0.0,1.5,0.01,0.02,0.03\n"
+        "0.1,0.3,0.0,1.0,0.04,0.05,0.06\n",
+        encoding="utf-8",
+    )
+
+    app = ThesisMeltPoolGeometryPart()
+    app.args = _build_args(tmp_path / "unused", sampling_mode="xy-grid")
+    monkeypatch.setattr(app, "parse_execute_arguments", lambda: None)
+    monkeypatch.setattr(app, "require_supported_3dthesis_version", lambda: "4.0.0")
+    monkeypatch.setattr(app, "get_step_output_paths", lambda: [str(output_path)])
+    monkeypatch.setattr(app, "get_case_dirs", lambda output_paths=None: [str(case_dir)])
+    monkeypatch.setattr(
+        app,
+        "run_case",
+        lambda proc_list, check_for_existing_results=True: [None, proc_list],
+    )
+
+    app.execute()
+
+    written = pd.read_csv(output_path)
+    assert list(written.columns) == [
+        "x (m)",
+        "y (m)",
+        "time (s)",
+        "length (m)",
+        "width (m)",
+        "depth (m)",
+    ]
+    assert written.to_dict(orient="records") == [
+        {
+            "x (m)": 0.1,
+            "y (m)": 0.3,
+            "time (s)": 1.0,
+            "length (m)": 0.05,
+            "width (m)": 0.04,
+            "depth (m)": 0.06,
+        },
+        {
+            "x (m)": 0.2,
+            "y (m)": 0.4,
+            "time (s)": 1.5,
+            "length (m)": 0.02,
+            "width (m)": 0.01,
+            "depth (m)": 0.03,
+        },
+    ]
+
+
 def test_melt_pool_geometry_segment_sampling_mode_ignores_comment_preamble(tmp_path):
     segment_dir = tmp_path / "path_segment_000"
     segment_dir.mkdir()


### PR DESCRIPTION
## Summary

Fixes bug with post-processing of 3DThesis melt pool geometry simulations when using the interpolation option. 

## Related issues

- No related issues.
- Connected to 3DThesis PR: https://github.com/ORNL-MDF/3DThesis/pull/40

## Details

- Bug fix: fixes behavior to match desired behavior for post-processing 3DThesis output into Myna's expected format. The interpolation option in 3DThesis generates columns like `MP_Width_Interp` instead of `MP_Width`, so this updates the key-lookup to handle that case.

## Impact

- Low impact: Minor change in columns that are searched by 3DThesis app. Adds extension point for quick changes in the future if 3DThesis columns change, though this is unlikely.

## Testing strategy

- Adds unit test, so CI should cover changes
- Tests passed locally with pytest and pre-commit

## Checklist

- [x] Architecture/docs impact considered. Updated `ARCHITECTURE.md` and/or
      developer docs where needed, or explained why not.
